### PR TITLE
Frameworks that build on Express: the Nest adapter, two CLI commands, and a suite for all of them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,6 +161,52 @@ jobs:
             - name: Fuzz against Express on a random seed
               run: npm run fuzz -- --rounds 20
 
+    # The frameworks that build on Express, each serving the same application twice: once on
+    # Express and once on this, with the two outputs compared byte for byte. Same rule as the
+    # comparison suite, and a job of its own because these dependencies are frameworks rather than
+    # middlewares: nobody should have to install Nest and Next to run `npm test`, and four of the
+    # seven compile an application before there is anything to serve.
+    integrations:
+        runs-on: ubuntu-latest
+        timeout-minutes: 25
+        steps:
+            - name: Checkout Source Tree
+              uses: actions/checkout@v7
+
+            - name: Cache Node.js dependencies
+              uses: actions/cache@v6
+              with:
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-
+
+            - name: Setup Node.js environment
+              uses: actions/setup-node@v7
+              with:
+                  node-version: "24"
+
+            - name: Install dependencies
+              run: npm install --include=dev
+
+            - name: Install the frameworks beside it
+              run: npm run integrations:install
+
+            # builds the four applications that need building, then runs every case
+            - name: Serve the same application on Express and on fulmine
+              run: npm run test:integrations
+
+            # what the two arms wrote when they disagreed, the same as the comparison suite keeps
+            - name: Keep what the arms wrote when they disagreed
+              if: failure()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: integration-failures
+                  path: |
+                      integrations/*.express.txt
+                      integrations/*.fulmine.txt
+                  if-no-files-found: ignore
+
     # Express's own suite, run against this project. A gate since the count reached 1130/0:
     # any failing test, any file without a result, or a moved express tag is red. Linux only:
     # the Windows exit hang the tool works around does not exist here

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,18 @@ examples/public/*.gz
 # the examples install fulmine.js from the directory above, so this lockfile is a copy of the
 # root's dependency list and goes stale every time one of them moves
 examples/package-lock.json
+integrations/package-lock.json
+
+# what the two arms of an integration case wrote when they disagreed, the same as test-failures/
+integrations/*.express.txt
+integrations/*.fulmine.txt
+
+# what each framework's build writes, plus the caches and generated types it keeps beside it.
+# integrations/build.js makes these, and remakes them when a source is newer
+integrations/apps/*/build/
+integrations/apps/*/dist/
+integrations/apps/*/.next/
+integrations/apps/*/.astro/
+integrations/apps/*/.svelte-kit/
+integrations/apps/*/.react-router/
+integrations/apps/*/package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,10 @@ coverage
 .nyc_output
 package-lock.json
 
+# the applications the integration cases serve, and what their builds write. Somebody else's
+# framework each, .astro and .svelte files included, which this cannot parse without their plugins
+integrations/apps
+
 # test fixtures and view templates: reformatting these changes their bytes, which
 # changes file sizes, etags and rendered output, and several tests assert on those
 tests/parts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,11 @@
 Fulmine.js is a drop-in Express 5 replacement on uWebSockets.js. Compatibility with Express is the
 product, so "Express does X" settles almost every design argument.
 
-Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) first: it explains the three test suites and how to
-write a comparison test. [`benchmark/README.md`](./benchmark/README.md) explains measuring.
-[`tools/README.md`](./tools/README.md) covers the fuzzers, the Express suite and releasing. This
-file only adds what those do not say.
+Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) first: it explains the test suites and how to write a
+comparison test. [`benchmark/README.md`](./benchmark/README.md) explains measuring.
+[`tools/README.md`](./tools/README.md) covers the fuzzers, the Express suite and releasing.
+[`integrations/README.md`](./integrations/README.md) covers the frameworks that build on Express.
+This file only adds what those do not say.
 
 ## Before you commit
 
@@ -23,6 +24,12 @@ npm run format:check
 
 A behaviour fix needs a comparison test under `tests/tests/`, and you must check it fails without
 the fix before claiming it covers anything. Reverting the fix and re-running is the only proof.
+
+`npm run test:integrations` is the same rule with a framework on top, and it is not in the list
+because it needs its own install, `npm run integrations:install`, and builds four applications the
+first time. Run it when you touch anything a framework sits on: the request and response surface,
+the body parsers, `writeHead`, the header methods. Both bugs it has found so far were in code the
+comparison suite covers well and applications reach differently from frameworks.
 
 Do not tag or release unless asked. Pushing a `v*` tag is what makes
 `.github/workflows/release.yml` publish to npm; `npm run release` creates that tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,9 @@ npm run benchmark:profile -- --scenario api-endpoint   # where the time goes, fo
 
 npm run test:express                            # Express's own test suite, run against this
 npm run test:express -- res.sendFile --verbose  # one area of it, with mocha's output
+
+npm run integrations:install                    # the frameworks that build on Express, beside the project
+npm run test:integrations                       # the same application on Express and on this
 ```
 
 The comparison suite is the load-bearing one. A test is a file that prints; the runner executes it
@@ -79,6 +82,19 @@ bug mine and its exit status says nothing; with `--ci`, which is how it runs in 
 red on any failing test or any file without a result. Read the header of `tools/express-suite.js`
 before reading its numbers: some of what it reports is Express testing its own internals, which the
 clone still has, and some is internals used as public API.
+
+`npm run test:integrations` is the comparison suite again, with a framework on top. Nest, Next,
+Astro, SvelteKit, React Router, Apollo and tRPC each serve one application, once on Express and once
+here, and the two outputs have to match. It lives in [`integrations/`](./integrations) rather than in
+`tests/` because those dependencies are frameworks rather than middlewares: heavy, installed on their
+own, four of them needing their own build to run first, and none of it something `npm test` should
+ask for. Read [`integrations/README.md`](./integrations/README.md) before adding a case.
+
+It earns its keep. Two runs, two real bugs, both in the gap a hand-written test does not reach:
+`req.body` was on every request where Express has none, which broke every tRPC mutation, and missing
+where Express has one, which Apollo answers with a 500; and `res.writeHead` was setting headers the
+way `res.set` does, so a content-type given to it came back with a charset Express never adds, on
+every page Astro and SvelteKit rendered.
 
 `npm run fuzz` is the third kind: it builds random applications, registers them on Express and on
 this, and compares the answers. A divergence prints the seed that reproduces it and the case shrunk

--- a/README.md
+++ b/README.md
@@ -179,34 +179,33 @@ with no cache at all on the serving side.
 ### NestJS
 
 `@nestjs/platform-express` takes an Express instance, so it takes this one, and everything in a Nest
-application keeps working. One line stands between that and the speed: the adapter wraps whatever
-instance it is given in `http.createServer()` and listens on that, which is the shim, so every
-request goes through `node:http` and the application runs at Express's pace. The app here already
-answers as an `http.Server`, so it can be the server rather than being wrapped in one:
+application keeps working. The adapter is in the package, so there is nothing to write:
 
 ```ts
 import { NestFactory } from "@nestjs/core";
-import { ExpressAdapter } from "@nestjs/platform-express";
-import fulmine from "fulmine.js";
+import { FulmineExpressAdapter } from "fulmine.js/nest";
 
-class FulmineAdapter extends ExpressAdapter {
-    initHttpServer() {
-        // instead of http.createServer(instance): listen() and close() are then µWS's
-        (this as any).httpServer = this.getInstance();
-    }
-}
-
-const app = await NestFactory.create(AppModule, new FulmineAdapter(fulmine()));
+const app = await NestFactory.create(AppModule, new FulmineExpressAdapter());
 await app.listen(3000);
 ```
+
+Pass your own application where it needs options, TLS being the usual reason:
+`new FulmineExpressAdapter(fulmine({ uwsOptions }))`. `@nestjs/platform-express` is an optional peer
+dependency, so nothing is installed for anyone who never imports this.
+
+What it changes is one line and two edges. The line: Nest's own adapter wraps whatever instance it
+is given in `http.createServer()` and listens on that, which is the shim, so every request goes
+through `node:http` and the application runs at Express's pace. The app here already answers as an
+`http.Server`, so it is the server rather than being put inside one. The edges:
+`forceCloseConnections` has nothing to destroy, since the sockets belong to µWS and nothing emits
+`connection`, so it now says so instead of quietly doing nothing; and Nest decides whether it has
+already added its body parsers by scanning `app.router.stack`, which is not there, so the adapter
+remembers instead of letting a second call add a second pair. `httpsOptions` is refused rather than
+silently starting a plaintext server: TLS is configured on the app, through `uwsOptions`.
 
 Measured on the same Nest application, controllers, pipes and body parsing unchanged: **1.2x on a
 route answering text and 1.9x on one answering JSON with a route parameter**. `app.close()` closes
 the port, as it does on the shim.
-
-Two things to know. `forceCloseConnections` has nothing to destroy, since the sockets belong to µWS
-and nothing emits `connection`, and Nest looks at `app.router.stack` to decide whether it has
-already added its body parsers, which is not there, so it adds them once more than it would.
 
 ### When Express is somebody else's dependency
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ See [Migrating](#migrating) for what it handles and what it deliberately does no
     - [Response](#response)
     - [Router](#router)
 - [Tested middlewares](#tested-middlewares)
+- [Tested frameworks](#tested-frameworks)
 - [Tested view engines](#tested-view-engines)
 - [Examples](./examples/README.md)
 - [Working on Fulmine](./CONTRIBUTING.md)
@@ -206,16 +207,19 @@ dependency, so nothing is installed for anyone who never imports this.
 What it changes is one line and two edges. The line: Nest's own adapter wraps whatever instance it
 is given in `http.createServer()` and listens on that, which is the shim, so every request goes
 through `node:http` and the application runs at Express's pace. The app here already answers as an
-`http.Server`, so it is the server rather than being put inside one. The edges:
-`forceCloseConnections` has nothing to destroy, since the sockets belong to µWS and nothing emits
-`connection`, so it now says so instead of quietly doing nothing; and Nest decides whether it has
-already added its body parsers by scanning `app.router.stack`, which is not there, so the adapter
-remembers instead of letting a second call add a second pair. `httpsOptions` is refused rather than
-silently starting a plaintext server: TLS is configured on the app, through `uwsOptions`.
+`http.Server`, so it is the server rather than being put inside one. The edges: `forceCloseConnections`
+has nothing to destroy, since the sockets belong to µWS and nothing emits `connection`, so it now
+says so instead of quietly doing nothing; and Nest decides whether it has already added its body
+parsers by scanning `app.router.stack`, which is not there, so the adapter remembers instead of
+letting a second call add a second pair. `httpsOptions` is refused rather than silently starting a
+plaintext server: TLS is configured on the app, through `uwsOptions`.
 
 Measured on the same Nest application, controllers, pipes and body parsing unchanged: **1.2x on a
 route answering text and 1.9x on one answering JSON with a route parameter**. `app.close()` closes
 the port, as it does on the shim.
+
+A Nest application answering the same bytes on both is [a case in the integration
+suite](./integrations/cases/nest.js), so this is tested rather than claimed.
 
 ### When Express is somebody else's dependency
 
@@ -874,6 +878,29 @@ Almost all middlewares that are compatible with Express are compatible with Fulm
 [tsoa](https://github.com/lukeautry/tsoa) works too, but it is not in the suite above: it resolves
 `express` itself, so testing it here needs a dependency override rather than the one-line swap
 everything else takes.
+
+## Tested frameworks
+
+The list above is middlewares. A framework built on Express is a much larger user of the Express
+surface than any application is, so those have a suite of their own, in
+[`integrations/`](./integrations): the same application served twice, once on Express and once here,
+with the two outputs compared byte for byte. The four that render pages are built first, by that
+suite, so what is compared is what their own build produces.
+
+- ✅ [NestJS](https://nestjs.com) through [`fulmine.js/nest`](#nestjs)
+- ✅ [Next.js](https://nextjs.org) as a custom server, `next().getRequestHandler()`
+- ✅ [Astro](https://astro.build) through `@astrojs/node` in middleware mode
+- ✅ [SvelteKit](https://svelte.dev/docs/kit) through `@sveltejs/adapter-node`
+- ✅ [React Router v7](https://reactrouter.com) through `@react-router/express`
+- ✅ [Apollo Server](https://www.apollographql.com/docs/apollo-server) through
+  [`@as-integrations/express5`](https://www.npmjs.com/package/@as-integrations/express5)
+- ✅ [tRPC](https://trpc.io) through `@trpc/server/adapters/express`
+- ✅ [Angular SSR](#angular-ssr), which is an ordinary Express `server.ts` plus one line of build
+  configuration
+
+Each of these mounts on an ordinary Express application, so there is nothing to install and nothing
+to configure beyond what that framework already asks for. Nest is the exception, and only because
+its adapter decides what to listen on: that one is [`fulmine.js/nest`](#nestjs).
 
 ## Tested view engines
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ There is a command that does that replacing for you, across a whole project, and
 npx fulmine.js verify              # can this machine and this image even run it
 npx fulmine.js migrate --dry-run   # say what it would change, change nothing
 npx fulmine.js migrate             # do it
+npx fulmine.js override            # when a framework requires express in its own code, not in yours
+npx fulmine.js angular             # angular.json's server build, which esbuild would otherwise inline
 npx fulmine.js differences         # just the list of what to check by hand
 npx fulmine.js profile             # what listen() decided about each route
 npx fulmine.js explain /api/items  # what happens when a request for that route arrives
@@ -155,8 +157,16 @@ The `server.ts` that `ng add @angular/ssr` generates is an ordinary Express appl
 one-line change applies, and `@angular/ssr`'s own `AngularNodeAppEngine` and
 `writeResponseToNodeResponse` work against Fulmine's request and response unchanged. One extra step
 is needed, and it is Angular's build rather than this library: the server bundle is built with
-esbuild, which tries to inline every dependency and cannot load µWS's native binary. Declare the two
-as external in `angular.json`:
+esbuild, which tries to inline every dependency and cannot load µWS's native binary. The two names
+have to be declared external in `angular.json`, which is what this writes:
+
+```sh
+npx fulmine.js angular             # every server build in angular.json
+npx fulmine.js angular --dry-run   # say what it would write, write nothing
+```
+
+It adds this to each build target that produces a server bundle, and leaves the browser-only ones
+alone:
 
 ```json
 "architect": { "build": { "options": {
@@ -211,7 +221,16 @@ the port, as it does on the shim.
 
 A framework built on Express does not `require("express")` in your code, it requires it in its own,
 so there is nothing for `migrate` to rewrite. Every package manager can answer `express` with this
-package instead, for your project and everything under it:
+package instead, for your project and everything under it, and this writes the block for whichever
+one your project uses:
+
+```sh
+npx fulmine.js override             # read the lockfile, write the block, say what to run next
+npx fulmine.js override --dry-run   # say what it would write, write nothing
+```
+
+It refuses rather than overwrites where a substitution is already there and is not this package. By
+hand it is one of these:
 
 ```jsonc
 // npm and its lockfile, in package.json

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,17 @@ import jsdoc from "eslint-plugin-jsdoc";
 
 export default [
     {
-        ignores: ["node_modules/**", "coverage/**", ".nyc_output/**", "benchmark/assets/**", "src/types.d.ts"]
+        ignores: [
+            "node_modules/**",
+            "coverage/**",
+            ".nyc_output/**",
+            "benchmark/assets/**",
+            "src/types.d.ts",
+            // the applications the integration cases serve, and what their builds write. Each one
+            // is somebody else's framework with its own conventions, modules and JSX included, and
+            // teaching this config four dialects to lint four fixtures is not worth it
+            "integrations/apps/**"
+        ]
     },
     js.configs.recommended,
     {

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,77 @@
+# Integrations
+
+The frameworks that build on Express, each serving the same application twice: once on Express and
+once on Fulmine, with the two outputs compared byte for byte. Same rule as the comparison suite in
+[`tests/`](../tests), and the same reason for it. A framework is a much larger user of the Express
+surface than any application is, so it reaches parts of it no test written by hand would think to
+reach. The first two runs of this directory found two real bugs, and both were in that gap:
+
+- `req.body` was on every request where Express has none, which broke every tRPC mutation, and
+  missing where Express has one, which Apollo answers with a 500.
+- `res.writeHead` set its headers the way `res.set` does, so a `content-type` given to it came out
+  with a charset appended. It is node's method and Express does not override it. Every framework
+  that renders a page builds its own response and writes it with `writeHead`, so the charset was on
+  every page Astro and SvelteKit served.
+
+```sh
+npm run integrations:install   # the frameworks, and fulmine.js from the directory above
+npm run test:integrations      # build what needs building, then every case
+cd integrations && node run.js trpc     # just that one
+cd integrations && node build.js --force  # rebuild the applications from scratch
+```
+
+| Case                                       | What it serves                                                                                    |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| [nest.js](./cases/nest.js)                 | a Nest controller with a pipe, a body and an exception filter, through the adapter                |
+| [apollo.js](./cases/apollo.js)             | Apollo Server through `@as-integrations/express5`                                                 |
+| [trpc.js](./cases/trpc.js)                 | a tRPC router through `@trpc/server/adapters/express`                                             |
+| [astro.js](./cases/astro.js)               | `@astrojs/node` in middleware mode, including the `next()` it calls for a path it does not answer |
+| [sveltekit.js](./cases/sveltekit.js)       | the handler `@sveltejs/adapter-node` builds                                                       |
+| [react-router.js](./cases/react-router.js) | React Router v7 through `@react-router/express`                                                   |
+| [next.js](./cases/next.js)                 | Next.js as a custom server, `next().getRequestHandler()`                                          |
+
+The first three are libraries: a case requires them and runs. The last four compile an application
+first, so each keeps a small one in [`apps/`](./apps) and [`build.js`](./build.js) builds it before
+the case runs. A build already there and newer than its sources is skipped, so running one case
+twice costs nothing.
+
+Between them the four cover both halves of the surface. Astro, SvelteKit and Next hand the node
+request and response to a handler that reads the stream and writes with `writeHead`; React Router's
+adapter is written for Express and goes through `res.status`, `res.set` and the response stream. The
+`writeHead` bug above was only ever going to be found by the first kind.
+
+## Writing a case
+
+A case is one file in `cases/`. It gets its framework from [`arm.js`](./arm.js), never by requiring
+`express` or `fulmine.js` directly, and that is the whole trick: the runner runs the file twice with
+`INTEGRATION_ARM` set differently and the file does not know which run it is in.
+
+Four rules, and the first three are the comparison suite's:
+
+- **Print what is being compared.** `fetchTest` from [`tests/helpers.js`](../tests/helpers.js) prints
+  the status and the headers worth comparing; the body is yours to print. A whole rendered page is
+  better printed as its length: the build's asset hashes are in it, they are the same on both arms,
+  and they tell a reader nothing.
+- **Fetch one at a time**, through `sequential`. Two arms scheduling concurrent requests differently
+  would fail as a difference that is the event loop's rather than the framework's.
+- **Bind a fixed port**, written as `const PORT = 13801;` so the runner can wait for it to go quiet
+  between the arms. Take the next free number.
+- **Turn off anything carrying a stack trace, a path or a clock reading.** Apollo and tRPC both put
+  a stack in the error body outside production; React Router logs one when no route matches; Next
+  prints how long its config took to load. Each case here shows what silences its own.
+
+Nest is the one case that also picks its adapter from `arm.js`: the Express arm uses Nest's own
+`ExpressAdapter` and the Fulmine arm uses [`fulmine.js/nest`](../src/nest.js), which is the thing
+being tested.
+
+## Adding an application
+
+Put it in `apps/<name>/`, name the case `cases/<name>.js`, and add a row to `BUILDS` in
+`build.js` saying what builds it and which file proves it was built. Nothing else is wired up: the
+runner matches the case name to the directory.
+
+The applications share this directory's `node_modules` rather than each having their own, which is
+the one thing to know when a build behaves oddly. It has bitten once already: Astro's server bundle
+imports `cookie` and resolves it from where the bundle sits, which here finds Express's copy rather
+than Astro's, so `apps/astro/astro.config.mjs` bundles that one in instead. A real project has its
+own `node_modules` and never meets it.

--- a/integrations/apps/astro/astro.config.mjs
+++ b/integrations/apps/astro/astro.config.mjs
@@ -1,0 +1,15 @@
+import { defineConfig } from "astro/config";
+import node from "@astrojs/node";
+
+// middleware mode, whose dist/server/entry.mjs exports a handler an express application can mount.
+// standalone mode would start its own server instead, which is not what is being tested
+export default defineConfig({
+    output: "server",
+    adapter: node({ mode: "middleware" }),
+    devToolbar: { enabled: false },
+    // The built entry imports `cookie` and resolves it from where the bundle sits, which here is a
+    // directory under a shared node_modules holding express's copy rather than astro's. Bundling it
+    // in takes the resolution out of the equation; a real astro project has its own node_modules
+    // and never meets this.
+    vite: { ssr: { noExternal: ["cookie"] } }
+});

--- a/integrations/apps/astro/package.json
+++ b/integrations/apps/astro/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "fulmine-integration-astro",
+    "private": true,
+    "type": "module"
+}

--- a/integrations/apps/astro/src/pages/api/items.js
+++ b/integrations/apps/astro/src/pages/api/items.js
@@ -1,0 +1,24 @@
+export const prerender = false;
+
+/** a GET reading the query string */
+export function GET({ url }) {
+    const tag = url.searchParams.get("tag");
+    if (tag === "boom") {
+        return new Response(JSON.stringify({ error: "no tea here" }), {
+            status: 418,
+            headers: { "content-type": "application/json" }
+        });
+    }
+    return Response.json({ tag: tag ?? null });
+}
+
+/** a POST reading a JSON body, parsed by the handler rather than by a middleware */
+export async function POST({ request }) {
+    let body;
+    try {
+        body = await request.json();
+    } catch {
+        return Response.json({ error: "not json" }, { status: 400 });
+    }
+    return Response.json({ received: body, keys: Object.keys(body ?? {}).sort() }, { status: 201 });
+}

--- a/integrations/apps/astro/src/pages/index.astro
+++ b/integrations/apps/astro/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+const now = "fixed";
+---
+
+<html lang="en">
+    <head><meta charset="utf-8" /><title>astro</title></head>
+    <body>
+        <h1>hello from astro</h1>
+        <p>{now}</p>
+    </body>
+</html>

--- a/integrations/apps/next/app/api/items/route.js
+++ b/integrations/apps/next/app/api/items/route.js
@@ -1,0 +1,21 @@
+export const dynamic = "force-dynamic";
+
+/** a GET reading the query string */
+export function GET(request) {
+    const tag = new URL(request.url).searchParams.get("tag");
+    if (tag === "boom") {
+        return Response.json({ error: "no tea here" }, { status: 418 });
+    }
+    return Response.json({ tag: tag ?? null });
+}
+
+/** a POST reading a JSON body, parsed by the route rather than by a middleware */
+export async function POST(request) {
+    let body;
+    try {
+        body = await request.json();
+    } catch {
+        return Response.json({ error: "not json" }, { status: 400 });
+    }
+    return Response.json({ received: body, keys: Object.keys(body ?? {}).sort() }, { status: 201 });
+}

--- a/integrations/apps/next/app/layout.jsx
+++ b/integrations/apps/next/app/layout.jsx
@@ -1,0 +1,9 @@
+export const metadata = { title: "next" };
+
+export default function RootLayout({ children }) {
+    return (
+        <html lang="en">
+            <body>{children}</body>
+        </html>
+    );
+}

--- a/integrations/apps/next/app/page.jsx
+++ b/integrations/apps/next/app/page.jsx
@@ -1,0 +1,5 @@
+export const dynamic = "force-dynamic";
+
+export default function Page() {
+    return <h1>hello from next</h1>;
+}

--- a/integrations/apps/next/next.config.js
+++ b/integrations/apps/next/next.config.js
@@ -1,0 +1,9 @@
+const path = require("node:path");
+
+// A custom server takes the request handler, so there is nothing to configure but the noise.
+// turbopack.root is the integrations directory, which is where node_modules is: without it Next
+// picks between two lockfiles and warns about the ambiguity on every start, naming absolute paths
+// that differ per machine, and pointing it at this directory instead cuts it off from node_modules.
+module.exports = {
+    turbopack: { root: path.join(__dirname, "..", "..") }
+};

--- a/integrations/apps/next/package.json
+++ b/integrations/apps/next/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "fulmine-integration-next",
+    "private": true
+}

--- a/integrations/apps/react-router/app/root.jsx
+++ b/integrations/apps/react-router/app/root.jsx
@@ -1,0 +1,21 @@
+import { Links, Meta, Outlet, Scripts } from "react-router";
+
+export function Layout({ children }) {
+    return (
+        <html lang="en">
+            <head>
+                <meta charSet="utf-8" />
+                <Meta />
+                <Links />
+            </head>
+            <body>
+                {children}
+                <Scripts />
+            </body>
+        </html>
+    );
+}
+
+export default function App() {
+    return <Outlet />;
+}

--- a/integrations/apps/react-router/app/routes.js
+++ b/integrations/apps/react-router/app/routes.js
@@ -1,0 +1,3 @@
+import { index, route } from "@react-router/dev/routes";
+
+export default [index("routes/home.jsx"), route("api/items", "routes/items.js")];

--- a/integrations/apps/react-router/app/routes/home.jsx
+++ b/integrations/apps/react-router/app/routes/home.jsx
@@ -1,0 +1,3 @@
+export default function Home() {
+    return <h1>hello from react router</h1>;
+}

--- a/integrations/apps/react-router/app/routes/items.js
+++ b/integrations/apps/react-router/app/routes/items.js
@@ -1,0 +1,19 @@
+/** a GET reading the query string */
+export function loader({ request }) {
+    const tag = new URL(request.url).searchParams.get("tag");
+    if (tag === "boom") {
+        return Response.json({ error: "no tea here" }, { status: 418 });
+    }
+    return Response.json({ tag: tag ?? null });
+}
+
+/** a POST reading a JSON body, parsed by the route rather than by a middleware */
+export async function action({ request }) {
+    let body;
+    try {
+        body = await request.json();
+    } catch {
+        return Response.json({ error: "not json" }, { status: 400 });
+    }
+    return Response.json({ received: body, keys: Object.keys(body ?? {}).sort() }, { status: 201 });
+}

--- a/integrations/apps/react-router/package.json
+++ b/integrations/apps/react-router/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "fulmine-integration-react-router",
+    "private": true,
+    "type": "module",
+    "dependencies": {
+        "isbot": "^5"
+    }
+}

--- a/integrations/apps/react-router/public/hello.txt
+++ b/integrations/apps/react-router/public/hello.txt
@@ -1,0 +1,1 @@
+a static file, copied into the client build

--- a/integrations/apps/react-router/react-router.config.js
+++ b/integrations/apps/react-router/react-router.config.js
@@ -1,0 +1,2 @@
+// server side rendering, with no prerendering: the point is a handler answering requests
+export default { ssr: true };

--- a/integrations/apps/react-router/vite.config.js
+++ b/integrations/apps/react-router/vite.config.js
@@ -1,0 +1,3 @@
+import { reactRouter } from "@react-router/dev/vite";
+
+export default { plugins: [reactRouter()] };

--- a/integrations/apps/sveltekit/package.json
+++ b/integrations/apps/sveltekit/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "fulmine-integration-sveltekit",
+    "private": true,
+    "type": "module"
+}

--- a/integrations/apps/sveltekit/src/app.html
+++ b/integrations/apps/sveltekit/src/app.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        %sveltekit.head%
+    </head>
+    <body>
+        <div>%sveltekit.body%</div>
+    </body>
+</html>

--- a/integrations/apps/sveltekit/src/routes/+page.svelte
+++ b/integrations/apps/sveltekit/src/routes/+page.svelte
@@ -1,0 +1,1 @@
+<h1>hello from sveltekit</h1>

--- a/integrations/apps/sveltekit/src/routes/api/+server.js
+++ b/integrations/apps/sveltekit/src/routes/api/+server.js
@@ -1,0 +1,23 @@
+import { error, json } from "@sveltejs/kit";
+
+/** a GET reading the query string */
+export function GET({ url }) {
+    if (url.searchParams.get("tag") === "boom") {
+        // SvelteKit's own error, so the body is its error shape and carries no stack
+        error(418, "no tea here");
+    }
+    return json({ tag: url.searchParams.get("tag") ?? null });
+}
+
+/** a POST reading a JSON body, which the handler parses itself rather than through a middleware */
+export async function POST({ request }) {
+    let body;
+    try {
+        body = await request.json();
+    } catch {
+        // caught here rather than left to throw: an unhandled one makes SvelteKit log a node
+        // internal stack, and a stack is not something two arms should be compared on
+        error(400, "not json");
+    }
+    return json({ received: body, keys: Object.keys(body ?? {}).sort() }, { status: 201 });
+}

--- a/integrations/apps/sveltekit/svelte.config.js
+++ b/integrations/apps/sveltekit/svelte.config.js
@@ -1,0 +1,5 @@
+import adapter from "@sveltejs/adapter-node";
+
+// the node adapter, whose build/handler.js is an express-shaped middleware. That handler is what
+// the case mounts, and the whole reason this app exists
+export default { kit: { adapter: adapter() } };

--- a/integrations/apps/sveltekit/vite.config.js
+++ b/integrations/apps/sveltekit/vite.config.js
@@ -1,0 +1,3 @@
+import { sveltekit } from "@sveltejs/kit/vite";
+
+export default { plugins: [sveltekit()] };

--- a/integrations/arm.js
+++ b/integrations/arm.js
@@ -1,0 +1,34 @@
+// Which framework the case being run is served by.
+//
+// A case is one file, run twice: once with Express and once with Fulmine, and the two runs have to
+// print the same bytes. Same idea as the comparison suite in tests/, and a separate directory only
+// because these dependencies are frameworks rather than middlewares: they are heavy, they are not
+// what `npm test` gates on, and nobody should have to install Nest to run the test suite.
+
+const arm = process.env.INTEGRATION_ARM;
+
+if (arm !== "express" && arm !== "fulmine") {
+    throw new Error("INTEGRATION_ARM must be express or fulmine; run these through run.js");
+}
+
+/** The framework this arm serves with. Both are Express 5, one of them is this project. */
+const express = arm === "fulmine" ? require("fulmine.js") : require("express");
+
+/**
+ * The Nest HTTP adapter for this arm.
+ *
+ * The Fulmine arm is the whole point of the exercise: `fulmine.js/nest` is what a Nest application
+ * has to use to be served by µWS rather than through a node server wrapping it.
+ *
+ * @returns {any}
+ */
+function nestAdapter() {
+    if (arm === "fulmine") {
+        const { FulmineExpressAdapter } = require("fulmine.js/nest");
+        return new FulmineExpressAdapter();
+    }
+    const { ExpressAdapter } = require("@nestjs/platform-express");
+    return new ExpressAdapter();
+}
+
+module.exports = { arm, express, nestAdapter };

--- a/integrations/build.js
+++ b/integrations/build.js
@@ -1,0 +1,104 @@
+// Builds the applications under apps/, which four of the cases need before they can serve anything.
+//
+// Nest, Apollo and tRPC are libraries: a case requires them and runs. Astro, SvelteKit, React Router
+// and Next are frameworks that compile an application first, and what mounts on Express is the
+// thing their build produces. So those four keep a small application in apps/ and this builds it.
+//
+// A build is skipped when its output is already there and newer than every source that went into
+// it, which is what makes running one case twice cost nothing. `node build.js --force` rebuilds
+// anyway, and `node build.js astro` builds one.
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const APPS = path.join(__dirname, "apps");
+
+/** What each application is built with, and the file that says it has been. */
+const BUILDS = {
+    astro: { output: "dist/server/entry.mjs", command: "astro build" },
+    next: { output: ".next/BUILD_ID", command: "next build" },
+    "react-router": { output: "build/server/index.js", command: "react-router build" },
+    sveltekit: { output: "build/handler.js", command: "vite build" }
+};
+
+/** Directories a build writes into, which are not sources however new they are. */
+const OUTPUT_DIRS = new Set(["build", "dist", ".next", ".svelte-kit", ".astro", "node_modules"]);
+
+/**
+ * The newest mtime among the application's sources.
+ *
+ * @param {string} dir
+ * @returns {number} milliseconds, or 0 for a directory that is not there
+ */
+function newestSource(dir) {
+    let newest = 0;
+    /** @type {string[]} */
+    const stack = [dir];
+    while (stack.length) {
+        const current = /** @type {string} */ (stack.pop());
+        let entries;
+        try {
+            entries = fs.readdirSync(current, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+        for (const entry of entries) {
+            if (entry.isDirectory()) {
+                if (!OUTPUT_DIRS.has(entry.name)) stack.push(path.join(current, entry.name));
+                continue;
+            }
+            const { mtimeMs } = fs.statSync(path.join(current, entry.name));
+            if (mtimeMs > newest) newest = mtimeMs;
+        }
+    }
+    return newest;
+}
+
+/**
+ * Builds one application unless its output is already newer than its sources.
+ *
+ * @param {string} name a key of BUILDS
+ * @param {boolean} [force] build even when it looks up to date
+ * @returns {void}
+ */
+function ensureBuilt(name, force) {
+    const build = BUILDS[name];
+    if (!build) return; // a case with no application of its own, which is most of them
+    const dir = path.join(APPS, name);
+    const output = path.join(dir, build.output);
+
+    if (!force && fs.existsSync(output) && fs.statSync(output).mtimeMs >= newestSource(dir)) {
+        return;
+    }
+
+    console.log(`building ${name}`);
+    // shell: true so the name resolves through node_modules/.bin, where npm writes a .cmd wrapper
+    // on Windows and a shell script everywhere else
+    const result = spawnSync(build.command, {
+        cwd: dir,
+        shell: true,
+        stdio: "inherit",
+        env: { ...process.env, NEXT_TELEMETRY_DISABLED: "1", PATH: binPath() }
+    });
+    if (result.status !== 0) {
+        throw new Error(`${name}: \`${build.command}\` exited ${result.status}`);
+    }
+}
+
+/** PATH with this directory's node_modules/.bin in front of it. */
+function binPath() {
+    const bin = path.join(__dirname, "node_modules", ".bin");
+    const current = process.env.PATH ?? process.env.Path ?? "";
+    return `${bin}${path.delimiter}${current}`;
+}
+
+module.exports = { ensureBuilt, BUILDS };
+
+if (require.main === module) {
+    const force = process.argv.includes("--force");
+    const wanted = process.argv.slice(2).filter((arg) => !arg.startsWith("--"));
+    for (const name of wanted.length ? wanted : Object.keys(BUILDS)) {
+        ensureBuilt(name, force);
+    }
+}

--- a/integrations/cases/apollo.js
+++ b/integrations/cases/apollo.js
@@ -1,0 +1,113 @@
+// Apollo Server through @as-integrations/express5: the GraphQL middleware mounted on the app.
+//
+// It reads the body off the request as any Express middleware does, writes with res.send, and sets
+// its own headers, so what is being compared here is the request and response surface under a
+// middleware nobody in this project wrote.
+
+const { ApolloServer } = require("@apollo/server");
+const { expressMiddleware } = require("@as-integrations/express5");
+const { express } = require("../arm.js");
+const { fetchTest, sequential } = require("../../tests/helpers.js");
+
+const PORT = 13802;
+
+const typeDefs = `#graphql
+    type Item {
+        id: Int!
+        name: String!
+    }
+    type Query {
+        item(id: Int!): Item
+        items: [Item!]!
+    }
+    type Mutation {
+        rename(id: Int!, name: String!): Item!
+    }
+`;
+
+const items = [
+    { id: 1, name: "primo" },
+    { id: 2, name: "secondo" }
+];
+
+const resolvers = {
+    Query: {
+        /** @returns {object|null} */
+        item: (/** @type {any} */ _parent, /** @type {any} */ args) => items.find((one) => one.id === args.id) ?? null,
+        /** @returns {object[]} */
+        items: () => items
+    },
+    Mutation: {
+        /** @returns {object} */
+        rename: (/** @type {any} */ _parent, /** @type {any} */ args) => {
+            const found = items.find((one) => one.id === args.id);
+            if (!found) throw new Error(`no item ${args.id}`);
+            found.name = args.name;
+            return found;
+        }
+    }
+};
+
+/** Posts a GraphQL document and prints what came back. */
+function post(query, variables) {
+    return async () => {
+        const response = await fetchTest(`http://localhost:${PORT}/graphql`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ query, variables })
+        });
+        console.log(await response.text());
+    };
+}
+
+/** Mounts Apollo on this arm's app and asks it a few questions. */
+async function main() {
+    const app = express();
+    // the stack in an error body names absolute paths and its async frames differ run to run, so
+    // it is not something two arms could ever be compared on
+    const server = new ApolloServer({ typeDefs, resolvers, includeStacktraceInErrorResponses: false });
+    await server.start();
+    app.use("/graphql", express.json(), expressMiddleware(server));
+    app.listen(PORT, async () => {
+        await sequential([
+            post("query { items { id name } }"),
+            post("query One($id: Int!) { item(id: $id) { id name } }", { id: 2 }),
+            post("query One($id: Int!) { item(id: $id) { id name } }", { id: 99 }),
+            // a field that is not in the schema: Apollo answers 400 with its own error shape
+            post("query { items { id colour } }"),
+            post("mutation Rename($id: Int!, $name: String!) { rename(id: $id, name: $name) { id name } }", {
+                id: 1,
+                name: "rinominato"
+            }),
+            // not JSON, so the middleware refuses before any resolver runs
+            async () => {
+                const response = await fetchTest(`http://localhost:${PORT}/graphql`, {
+                    method: "POST",
+                    headers: { "content-type": "text/plain" },
+                    body: "{ items { id } }"
+                });
+                console.log(await response.text());
+            },
+            // the GET path: the document comes off the query string, and the preflight header is
+            // what gets it past Apollo's CSRF guard
+            async () => {
+                const query = encodeURIComponent("query { items { id name } }");
+                const response = await fetchTest(`http://localhost:${PORT}/graphql?query=${query}`, {
+                    headers: { "apollo-require-preflight": "true" }
+                });
+                console.log(await response.text());
+            },
+            // GET with nothing to run, which the middleware refuses
+            async () => {
+                const response = await fetchTest(`http://localhost:${PORT}/graphql`, {
+                    headers: { "apollo-require-preflight": "true" }
+                });
+                console.log(await response.text());
+            }
+        ]);
+        await server.stop();
+        process.exit(0);
+    });
+}
+
+main();

--- a/integrations/cases/astro.js
+++ b/integrations/cases/astro.js
@@ -1,0 +1,59 @@
+// Astro through @astrojs/node in middleware mode: the handler its build exports, mounted as
+// middleware.
+//
+// Same shape as the SvelteKit case and for the same reason: the handler reads the node request and
+// writes the node response rather than using the Express surface, so what it exercises is the
+// compatibility layer underneath. It differs in one thing worth having both of: Astro's handler
+// takes `next`, and calls it for a path it does not answer, so an Express route after it still
+// gets its turn.
+//
+// The app it serves is in apps/astro, and run.js builds it before this runs.
+
+const { express } = require("../arm.js");
+const { fetchTest, sequential } = require("../../tests/helpers.js");
+
+const PORT = 13805;
+
+/** Fetches, prints the headers, and prints the body unless it is a whole rendered page. */
+function ask(label, path, init) {
+    return async () => {
+        const response = await fetchTest(`http://localhost:${PORT}${path}`, init);
+        const text = await response.text();
+        console.log(label, text.length > 400 ? `${text.length} bytes` : text);
+    };
+}
+
+async function main() {
+    const { handler } = await import("../apps/astro/dist/server/entry.mjs");
+    const app = express();
+    app.use(handler);
+    // reached only because the handler called next() for a path Astro does not answer
+    app.get("/after", (req, res) => res.json({ reached: true, url: req.originalUrl }));
+    app.listen(PORT, async () => {
+        await sequential([
+            ask("page", "/"),
+            ask("api", "/api/items"),
+            ask("api query", "/api/items?tag=blue"),
+            ask("api post", "/api/items", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ b: 2, a: 1 })
+            }),
+            ask("api bad json", "/api/items", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: "{"
+            }),
+            ask("api error", "/api/items?tag=boom"),
+            // the endpoint exports no DELETE, which Astro answers itself
+            ask("api delete", "/api/items", { method: "DELETE" }),
+            // Astro does not answer this one, so it calls next() and the route below it does
+            ask("after", "/after"),
+            // and nothing answers this one at all, which is Express's 404 rather than Astro's
+            ask("missing", "/nope")
+        ]);
+        process.exit(0);
+    });
+}
+
+main();

--- a/integrations/cases/nest.js
+++ b/integrations/cases/nest.js
@@ -1,0 +1,132 @@
+// NestJS through @nestjs/platform-express: a controller, a pipe, a body and an exception filter,
+// answering the same bytes on both arms.
+//
+// The decorators are applied by hand because this suite has no TypeScript build and a decorator is
+// only a function. What it costs is four lines per route; what it saves is a compiler in the way of
+// a test whose subject is the adapter.
+
+require("reflect-metadata");
+const {
+    Module,
+    Controller,
+    Get,
+    Post,
+    Param,
+    Body,
+    Query,
+    ParseIntPipe,
+    HttpCode,
+    NotFoundException
+} = require("@nestjs/common");
+const { NestFactory } = require("@nestjs/core");
+const { nestAdapter } = require("../arm.js");
+const { fetchTest, sequential } = require("../../tests/helpers.js");
+
+const PORT = 13801;
+
+/**
+ * Applies a method decorator the way the TypeScript emit would, descriptor included.
+ *
+ * @param {Function} target the class
+ * @param {string} key the method
+ * @param {Function} decorator what `@Get()` and friends return
+ * @returns {void}
+ */
+function method(target, key, decorator) {
+    const descriptor = /** @type {PropertyDescriptor} */ (Object.getOwnPropertyDescriptor(target.prototype, key));
+    decorator(target.prototype, key, descriptor);
+    Object.defineProperty(target.prototype, key, descriptor);
+}
+
+/**
+ * Applies a parameter decorator, which takes the position rather than a descriptor.
+ *
+ * @param {Function} target the class
+ * @param {string} key the method
+ * @param {number} index which argument
+ * @param {Function} decorator what `@Param()` and friends return
+ * @returns {void}
+ */
+function param(target, key, index, decorator) {
+    decorator(target.prototype, key, index);
+}
+
+class ItemsController {
+    /** @returns {string} a plain string, which Nest sends as text/html */
+    hello() {
+        return "hello from nest";
+    }
+
+    /**
+     * @param {number} id through ParseIntPipe, so a non-numeric one is a 400 from Nest itself
+     * @param {string} [tag] from the query string
+     * @returns {object}
+     */
+    one(id, tag) {
+        if (id === 404) {
+            throw new NotFoundException(`no item ${id}`);
+        }
+        return { id, tag: tag ?? null, kind: typeof id };
+    }
+
+    /**
+     * @param {any} body parsed by the body parser Nest registers
+     * @returns {object}
+     */
+    create(body) {
+        return { received: body, keys: Object.keys(body ?? {}).sort() };
+    }
+}
+
+param(ItemsController, "one", 0, Param("id", ParseIntPipe));
+param(ItemsController, "one", 1, Query("tag"));
+param(ItemsController, "create", 0, Body());
+method(ItemsController, "hello", Get());
+method(ItemsController, "one", Get(":id"));
+method(ItemsController, "create", Post());
+method(ItemsController, "create", HttpCode(201));
+Controller("items")(ItemsController);
+
+class AppModule {}
+Module({ controllers: [ItemsController] })(AppModule);
+
+/** Serves the module on this arm's adapter and sends the same requests to it. */
+async function main() {
+    const app = await NestFactory.create(AppModule, nestAdapter(), { logger: false });
+    await app.listen(PORT);
+
+    const base = `http://localhost:${PORT}/items`;
+    await sequential([
+        async () => console.log(await (await fetchTest(base)).text()),
+        async () => console.log(await (await fetchTest(`${base}/7?tag=blue`)).text()),
+        async () => console.log(await (await fetchTest(`${base}/404`)).text()),
+        async () => console.log(await (await fetchTest(`${base}/nope`)).text()),
+        async () =>
+            console.log(
+                await (
+                    await fetchTest(base, {
+                        method: "POST",
+                        headers: { "content-type": "application/json" },
+                        body: JSON.stringify({ b: 2, a: 1 })
+                    })
+                ).text()
+            ),
+        async () =>
+            console.log(
+                await (
+                    await fetchTest(base, {
+                        method: "POST",
+                        headers: { "content-type": "application/x-www-form-urlencoded" },
+                        body: "name=simone&city=napoli"
+                    })
+                ).text()
+            ),
+        // no route: Nest's own 404, which is the adapter's not-found handler rather than Express's
+        async () => console.log(await (await fetchTest(`http://localhost:${PORT}/missing`)).text())
+    ]);
+
+    await app.close();
+    process.exit(0);
+}
+
+main();

--- a/integrations/cases/next.js
+++ b/integrations/cases/next.js
@@ -1,0 +1,86 @@
+// Next.js as a custom server: next().getRequestHandler() mounted on an Express application.
+//
+// The custom server is the one integration here that is Next's own documented escape hatch rather
+// than an adapter somebody wrote for Express, and it is the heaviest user of the node surface of
+// the four: the handler reads the request as a stream, writes with res.writeHead and res.write, and
+// asks the response about things the others never touch.
+//
+// The app it serves is in apps/next, and run.js builds it before this runs. Telemetry is off, since
+// a request leaving the machine mid-test is not something a comparison should depend on.
+
+process.env.NEXT_TELEMETRY_DISABLED = "1";
+
+const path = require("node:path");
+const { express } = require("../arm.js");
+const { fetchTest, sequential } = require("../../tests/helpers.js");
+
+const PORT = 13807;
+const APP = path.join(__dirname, "..", "apps", "next");
+
+/** Fetches, prints the headers, and prints the body unless it is a whole rendered page. */
+function ask(label, url, init) {
+    return async () => {
+        const response = await fetchTest(`http://localhost:${PORT}${url}`, init);
+        const text = await response.text();
+        console.log(label, text.length > 400 ? `${text.length} bytes` : text);
+    };
+}
+
+/**
+ * Runs fn with everything the process writes thrown away.
+ *
+ * Next prints how long its config took to load, in milliseconds, which is a different number on
+ * every start and would be the only line the two arms ever disagreed on. Only the startup is
+ * silenced: everything the requests below print goes out normally.
+ *
+ * @param {() => Promise<any>} fn
+ * @returns {Promise<any>}
+ */
+async function quiet(fn) {
+    const out = process.stdout.write;
+    const err = process.stderr.write;
+    process.stdout.write = () => true;
+    process.stderr.write = () => true;
+    try {
+        return await fn();
+    } finally {
+        process.stdout.write = out;
+        process.stderr.write = err;
+    }
+}
+
+async function main() {
+    const next = require("next");
+    const nextApp = next({ dev: false, dir: APP });
+    await quiet(() => nextApp.prepare());
+    const handle = nextApp.getRequestHandler();
+
+    const app = express();
+    app.all("/{*splat}", (req, res) => handle(req, res));
+    app.listen(PORT, async () => {
+        await sequential([
+            ask("page", "/"),
+            ask("api", "/api/items"),
+            ask("api query", "/api/items?tag=blue"),
+            ask("api post", "/api/items", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ b: 2, a: 1 })
+            }),
+            ask("api bad json", "/api/items", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: "{"
+            }),
+            ask("api error", "/api/items?tag=boom"),
+            // the route exports no DELETE, so Next answers 405 with an Allow header of its own
+            ask("api delete", "/api/items", { method: "DELETE" }),
+            // Next's own not-found page rather than Express's 404
+            ask("missing", "/nope")
+        ]);
+        await nextApp.close();
+        process.exit(0);
+    });
+}
+
+main();

--- a/integrations/cases/react-router.js
+++ b/integrations/cases/react-router.js
@@ -1,0 +1,63 @@
+// React Router v7 through @react-router/express: createRequestHandler over the server build.
+//
+// The third of the handler-shaped cases, and the one that goes through an adapter written for
+// Express rather than for node: @react-router/express reads req.method, req.url, req.headers and
+// pipes the request into a web Request, then writes the answer back through res.status,
+// res.setHeader, res.set and the response stream. So this one lands on the Express surface where
+// SvelteKit and Astro land on the node one.
+//
+// The app it serves is in apps/react-router, and run.js builds it before this runs.
+
+const path = require("node:path");
+const { express } = require("../arm.js");
+const { fetchTest, sequential } = require("../../tests/helpers.js");
+
+const PORT = 13806;
+const APP = path.join(__dirname, "..", "apps", "react-router");
+
+/** Fetches, prints the headers, and prints the body unless it is a whole rendered page. */
+function ask(label, path, init) {
+    return async () => {
+        const response = await fetchTest(`http://localhost:${PORT}${path}`, init);
+        const text = await response.text();
+        console.log(label, text.length > 400 ? `${text.length} bytes` : text);
+    };
+}
+
+async function main() {
+    const { createRequestHandler } = await import("@react-router/express");
+    const build = await import("../apps/react-router/build/server/index.js");
+    const app = express();
+    app.use(express.static(path.join(APP, "build", "client")));
+    // the braces matter: Express 5's "/*splat" wants at least one segment, so "/" would fall
+    // through to the 404 and the page would never be rendered
+    app.all("/{*splat}", createRequestHandler({ build }));
+    app.listen(PORT, async () => {
+        await sequential([
+            ask("page", "/"),
+            ask("api", "/api/items"),
+            ask("api query", "/api/items?tag=blue"),
+            ask("api post", "/api/items", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ b: 2, a: 1 })
+            }),
+            ask("api bad json", "/api/items", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: "{"
+            }),
+            ask("api error", "/api/items?tag=boom"),
+            // the route exports a loader and an action, so DELETE reaches the action too
+            ask("api delete", "/api/items", { method: "DELETE" }),
+            // an asset off the client build, served by express.static in front of the handler
+            ask("asset", "/hello.txt")
+            // a path no route matches is deliberately not asked for: React Router logs the miss
+            // with a stack naming absolute paths, and a stack is not something two arms should be
+            // compared on
+        ]);
+        process.exit(0);
+    });
+}
+
+main();

--- a/integrations/cases/sveltekit.js
+++ b/integrations/cases/sveltekit.js
@@ -1,0 +1,58 @@
+// SvelteKit through @sveltejs/adapter-node: the handler its build produces, mounted as middleware.
+//
+// This is a different shape from the three cases beside it. The adapter's handler does not use the
+// Express request and response as an Express middleware does: it builds a web Request out of the
+// node one, runs the app, and writes the web Response back with res.writeHead and res.write. So
+// what is under test here is the node compatibility surface rather than the Express one, which is
+// exactly the half a hand-written test would not have thought to cover.
+//
+// The app it serves is in apps/sveltekit, and run.js builds it before this runs.
+
+const { express } = require("../arm.js");
+const { fetchTest, sequential } = require("../../tests/helpers.js");
+
+const PORT = 13804;
+
+/** Fetches, prints the headers, and prints the body with the build's own hashes masked. */
+function ask(label, path, init) {
+    return async () => {
+        const response = await fetchTest(`http://localhost:${PORT}${path}`, init);
+        const text = await response.text();
+        console.log(label, text.length > 400 ? `${text.length} bytes` : text);
+    };
+}
+
+async function main() {
+    const { handler } = await import("../apps/sveltekit/build/handler.js");
+    const app = express();
+    app.use(handler);
+    app.listen(PORT, async () => {
+        await sequential([
+            // the rendered page, whose length is printed rather than its bytes: the build's asset
+            // hashes are in it, and they are the same on both arms but tell nobody anything
+            ask("page", "/"),
+            ask("api", "/api"),
+            ask("api query", "/api?tag=blue"),
+            ask("api post", "/api", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ b: 2, a: 1 })
+            }),
+            // a body the endpoint cannot parse, so SvelteKit answers rather than the framework
+            ask("api bad json", "/api", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: "{"
+            }),
+            // an error raised by the endpoint, which SvelteKit turns into its own error shape
+            ask("api error", "/api?tag=boom"),
+            // a method the endpoint does not export: SvelteKit's own 405, with an Allow header
+            ask("api delete", "/api", { method: "DELETE" }),
+            // nothing routed there, which is SvelteKit's 404 page and not Express's
+            ask("missing", "/nope")
+        ]);
+        process.exit(0);
+    });
+}
+
+main();

--- a/integrations/cases/trpc.js
+++ b/integrations/cases/trpc.js
@@ -1,0 +1,91 @@
+// tRPC through @trpc/server/adapters/express: a router with a query, a mutation and an input that
+// fails validation.
+//
+// The adapter reads req.query and req.body, writes with res.end, and sets its own status, so this
+// covers a different corner of the response surface than the two cases beside it. The input
+// validator is written by hand rather than with zod: one dependency fewer, same code path.
+
+const { initTRPC, TRPCError } = require("@trpc/server");
+const { createExpressMiddleware } = require("@trpc/server/adapters/express");
+const { express } = require("../arm.js");
+const { fetchTest, sequential } = require("../../tests/helpers.js");
+
+const PORT = 13803;
+
+const t = initTRPC.context().create({
+    // tRPC puts the stack in the error body outside production, and it names absolute paths and
+    // frames that differ run to run. Dropping it leaves the code, the message and the status, which
+    // is what the two arms are being compared on
+    errorFormatter: ({ shape }) => ({ ...shape, data: { ...shape.data, stack: undefined } })
+});
+
+/**
+ * The input every procedure here takes: `{ id: number }`, and a throw is a 400 from tRPC.
+ *
+ * @param {any} value whatever arrived on the wire
+ * @returns {{id: number}}
+ */
+function withId(value) {
+    if (typeof value?.id !== "number" || !Number.isInteger(value.id)) {
+        throw new Error("id must be an integer");
+    }
+    return { id: value.id };
+}
+
+const items = new Map([
+    [1, "primo"],
+    [2, "secondo"]
+]);
+
+const appRouter = t.router({
+    list: t.procedure.query(() => [...items].map(([id, name]) => ({ id, name }))),
+    byId: t.procedure.input(withId).query(({ input }) => {
+        const name = items.get(input.id);
+        if (name === undefined) {
+            throw new TRPCError({ code: "NOT_FOUND", message: `no item ${input.id}` });
+        }
+        return { id: input.id, name };
+    }),
+    remove: t.procedure.input(withId).mutation(({ input }) => ({ removed: items.delete(input.id) }))
+});
+
+/** GETs a query procedure and prints the answer. */
+function query(path, input) {
+    return async () => {
+        const search = input === undefined ? "" : `?input=${encodeURIComponent(JSON.stringify(input))}`;
+        const response = await fetchTest(`http://localhost:${PORT}/trpc/${path}${search}`);
+        console.log(await response.text());
+    };
+}
+
+/** POSTs a mutation and prints the answer. */
+function mutate(path, input) {
+    return async () => {
+        const response = await fetchTest(`http://localhost:${PORT}/trpc/${path}`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(input)
+        });
+        console.log(await response.text());
+    };
+}
+
+const app = express();
+app.use("/trpc", createExpressMiddleware({ router: appRouter }));
+app.listen(PORT, async () => {
+    await sequential([
+        query("list"),
+        query("byId", { id: 2 }),
+        // a procedure that throws NOT_FOUND, which tRPC answers as 404 with its own error shape
+        query("byId", { id: 99 }),
+        // input the validator refuses: 400, and the message is the one thrown above
+        query("byId", { id: "two" }),
+        // no such procedure
+        query("nope"),
+        mutate("remove", { id: 1 }),
+        query("list"),
+        // a mutation asked for over GET, which the adapter refuses with 405
+        query("remove", { id: 2 })
+    ]);
+    process.exit(0);
+});

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "fulmine-integrations",
+    "version": "1.0.0",
+    "private": true,
+    "description": "The same application served by Express and by Fulmine, for frameworks that build on Express",
+    "scripts": {
+        "test": "node run.js"
+    },
+    "engines": {
+        "node": ">=22"
+    },
+    "dependencies": {
+        "@apollo/server": "^5.0.0",
+        "@as-integrations/express5": "^1.1.2",
+        "@nestjs/common": "^11.1.6",
+        "@nestjs/core": "^11.1.6",
+        "@nestjs/platform-express": "^11.1.6",
+        "@trpc/server": "^11.7.1",
+        "express": "^5",
+        "fulmine.js": "file:..",
+        "graphql": "^16.11.0",
+        "reflect-metadata": "^0.2.2",
+        "rxjs": "^7.8.2"
+    },
+    "devDependencies": {
+        "@astrojs/node": "^11.1.2",
+        "@react-router/dev": "^8.3.0",
+        "@react-router/express": "^8.3.0",
+        "@react-router/node": "^8.3.0",
+        "@sveltejs/adapter-node": "^5.5.7",
+        "@sveltejs/kit": "^2.70.2",
+        "@sveltejs/vite-plugin-svelte": "^7.3.0",
+        "astro": "^7.2.2",
+        "isbot": "^5.2.1",
+        "next": "^16.3.1",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-router": "^8.3.0",
+        "svelte": "^5.56.9",
+        "vite": "^8.2.1"
+    },
+    "allowScripts": {
+        "esbuild@0.28.2": true
+    }
+}

--- a/integrations/run.js
+++ b/integrations/run.js
@@ -1,0 +1,135 @@
+// npm --prefix integrations test           every case
+// npm --prefix integrations test nest      just that one
+//
+// Each case in cases/ is run twice, once with Express and once with Fulmine, and the two runs have
+// to print the same bytes. Same rule as the comparison suite in tests/, and the same reason: a
+// framework built on Express is a much larger user of the Express surface than any application is,
+// so it reaches parts of it no test written by hand would think to reach.
+//
+// The two arms never run at the same time. A case binds a fixed port and two µWS servers can hold
+// one port at once on Windows, which would have one arm reading the other's answers.
+
+const fs = require("fs");
+const path = require("path");
+const net = require("node:net");
+const test = require("node:test");
+const assert = require("node:assert");
+const { execFile } = require("node:child_process");
+const { ensureBuilt } = require("./build.js");
+
+const CASES_DIR = path.join(__dirname, "cases");
+const CASE_TIMEOUT_MS = 120000;
+const PORT_WAIT_STEPS = 200;
+const PORT_WAIT_MS = 25;
+const PORT_IN_SOURCE = /const PORT = (\d{4,5})/g;
+
+// see tests/win-exit-delay.cjs: without it every arm asserts at exit under Node 24+ on Windows
+const NODE_ARGS =
+    process.platform === "win32" ? ["--require", path.join(__dirname, "..", "tests", "win-exit-delay.cjs")] : [];
+
+/**
+ * @param {string} code
+ * @returns {number[]} the ports this case listens on
+ */
+function portsOf(code) {
+    return [...new Set([...code.matchAll(PORT_IN_SOURCE)].map((match) => Number(match[1])))];
+}
+
+/**
+ * @param {number} port
+ * @returns {Promise<boolean>} whether anything answers there right now
+ */
+function portBusy(port) {
+    return new Promise((resolve) => {
+        const socket = net.connect({ port, host: "127.0.0.1" });
+        const done = (/** @type {boolean} */ busy) => {
+            socket.destroy();
+            resolve(busy);
+        };
+        socket.once("connect", () => done(true));
+        socket.once("error", () => done(false));
+        socket.setTimeout(500, () => done(false));
+    });
+}
+
+/**
+ * Waits until nothing is listening on these ports, so one arm cannot reach the arm before it.
+ *
+ * @param {number[]} ports
+ * @returns {Promise<void>}
+ */
+async function waitForFreePorts(ports) {
+    for (const port of ports) {
+        for (let step = 0; step < PORT_WAIT_STEPS; step++) {
+            if (!(await portBusy(port))) break;
+            await new Promise((resolve) => setTimeout(resolve, PORT_WAIT_MS));
+        }
+    }
+}
+
+/**
+ * Runs one case on one arm and hands back everything it wrote.
+ *
+ * stderr is kept: a case that dies before printing anything would otherwise fail as an empty
+ * string against an empty string, which is the one way a comparison can pass by accident.
+ *
+ * @param {string} file the case
+ * @param {"express"|"fulmine"} arm
+ * @returns {Promise<string>}
+ */
+function runArm(file, arm) {
+    return new Promise((resolve, reject) => {
+        execFile(
+            process.execPath,
+            [...NODE_ARGS, file],
+            {
+                cwd: __dirname,
+                timeout: CASE_TIMEOUT_MS,
+                env: { ...process.env, INTEGRATION_ARM: arm },
+                maxBuffer: 32 * 1024 * 1024
+            },
+            (error, stdout, stderr) => {
+                if (error && !stdout) {
+                    reject(new Error(`${path.basename(file)} on ${arm}: ${error.message}\n${stderr}`));
+                    return;
+                }
+                resolve(stdout + (stderr ? `\n[stderr]\n${stderr}` : ""));
+            }
+        );
+    });
+}
+
+const wanted = process.argv[2];
+const cases = fs
+    .readdirSync(CASES_DIR)
+    .filter((name) => name.endsWith(".js"))
+    .filter((name) => !wanted || name.startsWith(wanted));
+
+if (!cases.length) {
+    console.error(wanted ? `no case matches ${wanted}` : "no cases in cases/");
+    process.exitCode = 1;
+}
+
+for (const name of cases) {
+    const file = path.join(CASES_DIR, name);
+    test(name, { timeout: CASE_TIMEOUT_MS * 2 }, async () => {
+        // a case whose name matches an application in apps/ serves what that build produced, so it
+        // is built first. Already built and untouched costs a directory walk and nothing else
+        ensureBuilt(name.replace(/\.js$/, ""));
+        const ports = portsOf(fs.readFileSync(file, "utf8"));
+        await waitForFreePorts(ports);
+        const expressOutput = await runArm(file, "express");
+        await waitForFreePorts(ports);
+        const fulmineOutput = await runArm(file, "fulmine");
+
+        if (fulmineOutput !== expressOutput) {
+            // written down rather than only diffed in the terminal, because these outputs are long
+            // and the interesting line is rarely the first one
+            const stem = path.join(__dirname, name.replace(/\.js$/, ""));
+            fs.writeFileSync(`${stem}.express.txt`, expressOutput);
+            fs.writeFileSync(`${stem}.fulmine.txt`, fulmineOutput);
+            console.error(`wrote ${stem}.express.txt and ${stem}.fulmine.txt`);
+        }
+        assert.strictEqual(fulmineOutput, expressOutput);
+    });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,9 @@
                 "@commitlint/cli": "^21.2.1",
                 "@commitlint/config-conventional": "^21.2.0",
                 "@eslint/js": "^10.0.1",
+                "@nestjs/common": "^11.2.1",
+                "@nestjs/core": "^11.2.1",
+                "@nestjs/platform-express": "^11.2.1",
                 "@release-it/conventional-changelog": "^12.0.0",
                 "@types/accepts": "^1.3.7",
                 "@types/bytes": "^3.1.5",
@@ -103,8 +106,10 @@
                 "pkg-pr-new": "^0.0.87",
                 "prettier": "^3.9.6",
                 "pug": "^3.0.4",
+                "reflect-metadata": "^0.2.2",
                 "release-it": "^21.0.1",
                 "response-time": "^2.3.4",
+                "rxjs": "^7.8.2",
                 "serve-favicon": "^2.5.1",
                 "serve-index": "^1.9.2",
                 "serve-static": "^2.2.1",
@@ -399,6 +404,17 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@borewit/text-codec": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+            "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/@colors/colors": {
@@ -1678,6 +1694,16 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@lukeed/csprng": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+            "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/@minimistjs/subarg": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@minimistjs/subarg/-/subarg-1.0.0.tgz",
@@ -1686,6 +1712,100 @@
             "license": "MIT",
             "dependencies": {
                 "minimist": "^1.1.0"
+            }
+        },
+        "node_modules/@nestjs/common": {
+            "version": "11.2.1",
+            "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.2.1.tgz",
+            "integrity": "sha512-SEgtP+M9DqNhQkgJIlJ3oTp3gemo/8owySovzMGmJj2kcfIH1G6QP45AAb8dE4a3IpVicpUvdDAy7Syk7ebjBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "file-type": "21.3.4",
+                "iterare": "1.2.1",
+                "load-esm": "1.0.3",
+                "tslib": "2.8.1",
+                "uid": "2.0.2"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/nest"
+            },
+            "peerDependencies": {
+                "class-transformer": ">=0.4.1",
+                "class-validator": ">=0.13.2",
+                "reflect-metadata": "^0.1.12 || ^0.2.0",
+                "rxjs": "^7.1.0"
+            },
+            "peerDependenciesMeta": {
+                "class-transformer": {
+                    "optional": true
+                },
+                "class-validator": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nestjs/core": {
+            "version": "11.2.1",
+            "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.2.1.tgz",
+            "integrity": "sha512-M5PWFU8NdRTgX9Po49d7TQKg7f5t8GAVUa/Esy4tmaMWcKugTzg3ZzpJfD3LEPMuRHjfs6+8pQYgtuP2uz3rDw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-safe-stringify": "2.1.1",
+                "iterare": "1.2.1",
+                "path-to-regexp": "8.4.2",
+                "tslib": "2.8.1",
+                "uid": "2.0.2"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/nest"
+            },
+            "peerDependencies": {
+                "@nestjs/common": "^11.0.0",
+                "@nestjs/microservices": "^11.0.0",
+                "@nestjs/platform-express": "^11.0.0",
+                "@nestjs/websockets": "^11.0.0",
+                "reflect-metadata": "^0.1.12 || ^0.2.0",
+                "rxjs": "^7.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@nestjs/microservices": {
+                    "optional": true
+                },
+                "@nestjs/platform-express": {
+                    "optional": true
+                },
+                "@nestjs/websockets": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nestjs/platform-express": {
+            "version": "11.2.1",
+            "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.2.1.tgz",
+            "integrity": "sha512-lbaVW94s1u8AJfgmBtdMPi16MEuFBiLrnflUIA9tZ9e5eoUsGTN7XXXRjU5kTTLgjnTCM53qgBXXGmTqmyfoQA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cors": "2.8.6",
+                "express": "5.2.1",
+                "multer": "2.2.0",
+                "path-to-regexp": "8.4.2",
+                "tslib": "2.8.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/nest"
+            },
+            "peerDependencies": {
+                "@nestjs/common": "^11.0.0",
+                "@nestjs/core": "^11.0.0"
             }
         },
         "node_modules/@noble/hashes": {
@@ -2083,6 +2203,31 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
             "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tokenizer/inflate": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+            "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "token-types": "^6.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/@tokenizer/token": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "dev": true,
             "license": "MIT"
         },
@@ -5748,6 +5893,25 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/file-type": {
+            "version": "21.3.4",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+            "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/inflate": "^0.4.1",
+                "strtok3": "^10.3.4",
+                "token-types": "^6.1.1",
+                "uint8array-extras": "^1.4.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+            }
+        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7239,6 +7403,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/iterare": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
+            "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/jest-diff": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
@@ -7585,6 +7759,26 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/load-esm": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
+            "integrity": "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/Borewit"
+                },
+                {
+                    "type": "buymeacoffee",
+                    "url": "https://buymeacoffee.com/borewit"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=13.2.0"
             }
         },
         "node_modules/locate-path": {
@@ -9028,6 +9222,17 @@
                 "node": "20 || >=22"
             }
         },
+        "node_modules/path-to-regexp": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -9664,6 +9869,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/reflect-metadata": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+            "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/reinterval": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
@@ -9959,17 +10171,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/router/node_modules/path-to-regexp": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
         "node_modules/run-applescript": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -10005,6 +10206,16 @@
             "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
+            }
+        },
+        "node_modules/rxjs": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
             }
         },
         "node_modules/safe-buffer": {
@@ -10705,6 +10916,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strtok3": {
+            "version": "10.3.5",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+            "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/token": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
         "node_modules/superagent": {
             "version": "10.3.0",
             "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -11011,6 +11239,25 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/token-types": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+            "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@borewit/text-codec": "^0.2.1",
+                "@tokenizer/token": "^0.3.0",
+                "ieee754": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
         "node_modules/trim-newlines": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -11174,6 +11421,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/uid": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+            "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@lukeed/csprng": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/uid-safe": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -11185,6 +11445,19 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/uint8array-extras": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+            "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
         "cover:full": "nyc --silent npm run test && nyc --silent --no-clean npm run test:unit && nyc --silent --no-clean npm run test:express && nyc report",
         "cover:check": "nyc check-coverage --statements 94.5 --branches 90 --functions 94 --lines 94.5",
         "examples:install": "npm --prefix examples install",
+        "test:integrations": "npm --prefix integrations test",
+        "integrations:install": "npm --prefix integrations install",
         "fuzz:wire": "node tools/wire-fuzz.js",
         "fuzz:headers": "node tools/header-fuzz.js",
         "fuzz:session": "node tools/session-fuzz.js"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,18 @@
     "version": "5.12.3",
     "description": "Drop-in Express 5 replacement on uWebSockets.js. Your existing middleware keeps working.",
     "main": "src/index.js",
+    "exports": {
+        ".": {
+            "types": "./src/types.d.ts",
+            "default": "./src/index.js"
+        },
+        "./nest": {
+            "types": "./src/nest.d.ts",
+            "default": "./src/nest.js"
+        },
+        "./package.json": "./package.json",
+        "./*": "./*"
+    },
     "bin": {
         "fulmine": "src/cli.js"
     },
@@ -93,10 +105,21 @@
         "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.69.0",
         "vary": "^1.1.2"
     },
+    "peerDependencies": {
+        "@nestjs/platform-express": ">=10"
+    },
+    "peerDependenciesMeta": {
+        "@nestjs/platform-express": {
+            "optional": true
+        }
+    },
     "devDependencies": {
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
         "@eslint/js": "^10.0.1",
+        "@nestjs/common": "^11.2.1",
+        "@nestjs/core": "^11.2.1",
+        "@nestjs/platform-express": "^11.2.1",
         "@release-it/conventional-changelog": "^12.0.0",
         "@types/accepts": "^1.3.7",
         "@types/bytes": "^3.1.5",
@@ -160,8 +183,10 @@
         "pkg-pr-new": "^0.0.87",
         "prettier": "^3.9.6",
         "pug": "^3.0.4",
+        "reflect-metadata": "^0.2.2",
         "release-it": "^21.0.1",
         "response-time": "^2.3.4",
+        "rxjs": "^7.8.2",
         "serve-favicon": "^2.5.1",
         "serve-index": "^1.9.2",
         "serve-static": "^2.2.1",

--- a/src/adopt.js
+++ b/src/adopt.js
@@ -72,21 +72,26 @@ function indentOf(source) {
 /**
  * Reads a JSON file, or explains why it could not be read rather than throwing a parser error.
  *
+ * The read is attempted rather than guarded by an existence check. Both commands go on to write the
+ * file they read, and a check on a path followed by a write to the same path is the shape of a race
+ * whatever the odds of losing it. `code` is what a caller names the missing file by.
+ *
  * @param {string} file
- * @returns {{data: any, source: string}|{error: string}}
+ * @returns {{data: any, source: string}|{error: string, code: string|undefined}}
  */
 function readJson(file) {
     let source;
     try {
         source = fs.readFileSync(file, "utf8");
-    } catch {
-        return { error: `${file} could not be read` };
+    } catch (e) {
+        const err = /** @type {NodeJS.ErrnoException} */ (e);
+        return { error: `${file} could not be read: ${err.message}`, code: err.code };
     }
     try {
         return { data: JSON.parse(source), source };
     } catch (e) {
         const err = /** @type {Error} */ (e);
-        return { error: `${file} is not valid JSON and was left alone: ${err.message}` };
+        return { error: `${file} is not valid JSON and was left alone: ${err.message}`, code: undefined };
     }
 }
 
@@ -162,14 +167,9 @@ function override(argv) {
     const dir = path.resolve(argv.find((arg) => !arg.startsWith("--")) ?? ".");
     const file = path.join(dir, "package.json");
 
-    if (!fs.existsSync(file)) {
-        console.error(`no package.json in ${dir}`);
-        return 1;
-    }
-
     const read = readJson(file);
     if ("error" in read) {
-        console.error(read.error);
+        console.error(read.code === "ENOENT" ? `no package.json in ${dir}` : read.error);
         return 1;
     }
     const { data: pkg, source } = read;
@@ -266,16 +266,14 @@ function serverBuilds(config) {
 function angular(argv) {
     const dryRun = argv.includes("--dry-run");
     const given = path.resolve(argv.find((arg) => !arg.startsWith("--")) ?? ".");
-    const file = fs.existsSync(given) && fs.statSync(given).isFile() ? given : path.join(given, "angular.json");
-
-    if (!fs.existsSync(file)) {
-        console.error(`no angular.json at ${file}`);
-        return 1;
-    }
+    // one stat and not an existence check followed by one: the argument may be the file itself or
+    // the directory holding it, and nothing is missing if it is neither
+    const stat = fs.statSync(given, { throwIfNoEntry: false });
+    const file = stat?.isFile() ? given : path.join(given, "angular.json");
 
     const read = readJson(file);
     if ("error" in read) {
-        console.error(read.error);
+        console.error(read.code === "ENOENT" ? `no angular.json at ${file}` : read.error);
         return 1;
     }
     const { data: config, source } = read;

--- a/src/adopt.js
+++ b/src/adopt.js
@@ -1,0 +1,320 @@
+/*
+Copyright 2026 Nigro Simone
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The two commands that edit a config file rather than source: `npx fulmine.js override` and
+// `npx fulmine.js angular`.
+//
+// `migrate` rewrites `require("express")` in your own files, which is all an application needs. The
+// two cases it cannot reach are both a line in a JSON file that nobody remembers the shape of:
+//
+//   override   A framework built on Express does not require it in your code, it requires it in its
+//              own, so there is no specifier to rewrite. Every package manager can answer `express`
+//              with this package instead, for the whole tree, and each one spells it differently.
+//   angular    An Angular server bundle is built with esbuild, which inlines every dependency and
+//              cannot load µWS's native binary. Two names in `externalDependencies` fix it, and
+//              nothing in the error message it fails with says so.
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const SELF = "fulmine.js";
+const REPLACES = "express";
+
+/** The major this package tracks, which is the range an override should ask for. */
+const MAJOR = require("../package.json").version.split(".")[0];
+
+/** Where each manager keeps its substitutions, and what to call it when telling someone. */
+const MANAGERS = {
+    npm: { keys: ["overrides"], reinstall: "npm install" },
+    pnpm: { keys: ["pnpm", "overrides"], reinstall: "pnpm install" },
+    yarn: { keys: ["resolutions"], reinstall: "yarn install" }
+};
+
+/** A lockfile, and the manager that wrote it. bun is here to be refused, see detectManager. */
+const LOCKFILES = [
+    ["pnpm-lock.yaml", "pnpm"],
+    ["yarn.lock", "yarn"],
+    ["package-lock.json", "npm"],
+    ["npm-shrinkwrap.json", "npm"],
+    ["bun.lock", "bun"],
+    ["bun.lockb", "bun"]
+];
+
+/**
+ * The indentation a file already uses, so rewriting it does not reformat every line.
+ *
+ * @param {string} source
+ * @returns {string|number} what JSON.stringify takes as its third argument
+ */
+function indentOf(source) {
+    const first = source.match(/\n([ \t]+)"/);
+    if (!first) {
+        return 4;
+    }
+    return first[1].startsWith("\t") ? "\t" : first[1].length;
+}
+
+/**
+ * Reads a JSON file, or explains why it could not be read rather than throwing a parser error.
+ *
+ * @param {string} file
+ * @returns {{data: any, source: string}|{error: string}}
+ */
+function readJson(file) {
+    let source;
+    try {
+        source = fs.readFileSync(file, "utf8");
+    } catch {
+        return { error: `${file} could not be read` };
+    }
+    try {
+        return { data: JSON.parse(source), source };
+    } catch (e) {
+        const err = /** @type {Error} */ (e);
+        return { error: `${file} is not valid JSON and was left alone: ${err.message}` };
+    }
+}
+
+/**
+ * Which package manager this project uses.
+ *
+ * The `packageManager` field is asked first: a project that declares one is using it whatever
+ * lockfiles are lying around. A project with neither gets npm, since that is what `npx` came with.
+ *
+ * @param {string} dir
+ * @param {any} pkg the parsed package.json
+ * @returns {{manager: string, why: string}}
+ */
+function detectManager(dir, pkg) {
+    const declared = typeof pkg.packageManager === "string" ? pkg.packageManager.split("@")[0] : undefined;
+    if (declared && (MANAGERS[declared] || declared === "bun")) {
+        return { manager: declared, why: `the packageManager field says ${declared}` };
+    }
+    for (const [file, manager] of LOCKFILES) {
+        if (fs.existsSync(path.join(dir, file))) {
+            return { manager, why: `${file} is here` };
+        }
+    }
+    return { manager: "npm", why: "no lockfile and no packageManager field, so npm" };
+}
+
+/**
+ * Reads a nested key, and answers undefined rather than throwing on a missing level.
+ *
+ * @param {any} object
+ * @param {string[]} keys
+ * @returns {any}
+ */
+function readPath(object, keys) {
+    let at = object;
+    for (const key of keys) {
+        if (at === null || typeof at !== "object") return undefined;
+        at = at[key];
+    }
+    return at;
+}
+
+/**
+ * Writes a nested key, making the levels above it as it goes.
+ *
+ * @param {any} object
+ * @param {string[]} keys
+ * @param {any} value
+ * @returns {void}
+ */
+function writePath(object, keys, value) {
+    let at = object;
+    for (const key of keys.slice(0, -1)) {
+        if (at[key] === null || typeof at[key] !== "object") at[key] = {};
+        at = at[key];
+    }
+    at[keys[keys.length - 1]] = value;
+}
+
+/**
+ * npx fulmine.js override [dir] [--dry-run]
+ *
+ * Puts the substitution in package.json where this project's package manager reads it, and says
+ * what to run next. It deliberately does not run the install: the reinstall throws away
+ * node_modules, and that is not something a command should do to somebody's working tree without
+ * being watched.
+ *
+ * @param {string[]} argv everything after the command name
+ * @returns {number} exit code
+ */
+function override(argv) {
+    const dryRun = argv.includes("--dry-run");
+    const dir = path.resolve(argv.find((arg) => !arg.startsWith("--")) ?? ".");
+    const file = path.join(dir, "package.json");
+
+    if (!fs.existsSync(file)) {
+        console.error(`no package.json in ${dir}`);
+        return 1;
+    }
+
+    const read = readJson(file);
+    if ("error" in read) {
+        console.error(read.error);
+        return 1;
+    }
+    const { data: pkg, source } = read;
+
+    const { manager, why } = detectManager(dir, pkg);
+    if (manager === "bun") {
+        console.error(
+            `this project uses bun (${why}), and bun cannot run this package at all: µWebSockets.js\n` +
+                "is a native node addon and bun does not load it. Nothing was changed."
+        );
+        return 1;
+    }
+
+    const { keys, reinstall } = MANAGERS[manager];
+    const where = keys.join(".");
+    const wanted = `npm:${SELF}@^${MAJOR}`;
+
+    const existing = readPath(pkg, [...keys, REPLACES]);
+    if (existing === wanted) {
+        console.log(`${where}.${REPLACES} already says ${wanted}, so there is nothing to change.`);
+        console.log(`Check it took: ${manager === "npm" ? "npm ls express" : `${manager} why express`}`);
+        return 0;
+    }
+    if (existing !== undefined) {
+        console.error(
+            `${where}.${REPLACES} already says ${JSON.stringify(existing)}, which is not this package.\n` +
+                "Nothing was changed: overwriting somebody else's substitution is not this command's call."
+        );
+        return 1;
+    }
+
+    writePath(pkg, [...keys, REPLACES], wanted);
+    const rewritten = JSON.stringify(pkg, null, indentOf(source)) + "\n";
+
+    // the block on its own, so what was added can be read without diffing a whole package.json
+    const shown = {};
+    writePath(shown, keys, { [REPLACES]: wanted });
+    console.log(`${manager}, because ${why}`);
+    console.log(`${dryRun ? "would add" : "added"} to package.json:\n`);
+    console.log(
+        JSON.stringify(shown, null, 2)
+            .split("\n")
+            .map((line) => `  ${line}`)
+            .join("\n") + "\n"
+    );
+    if (!dryRun) {
+        fs.writeFileSync(file, rewritten);
+    }
+
+    console.log("Then reinstall, so the lockfile is written again:\n");
+    console.log(`  rm -rf node_modules && ${reinstall}\n`);
+    const check = manager === "npm" ? "npm ls express" : `${manager} why express`;
+    console.log(`It took when \`${check}\` names ${SELF}.\n`);
+    console.log("Two things to know before you trust it:\n");
+    console.log(`  The substitution reaches every dependency that asks for ${REPLACES}, including ones you have`);
+    console.log("  never looked at. Run your own tests afterwards, and read `npx fulmine.js differences`:");
+    console.log("  what a framework does with Express is usually more than what an application does.\n");
+    console.log(`  A package that reaches into ${REPLACES}/lib/... rather than its public surface will not find`);
+    console.log("  what it expects, since the files there are ours.\n");
+    return 0;
+}
+
+/**
+ * Every build target in an angular.json that produces a server bundle.
+ *
+ * A browser-only build has nothing to declare external: the bundle it makes never loads µWS. What
+ * marks a server build is `ssr`, `server` or `outputMode` in its options, which is what `ng add
+ * @angular/ssr` writes.
+ *
+ * @param {any} config the parsed angular.json
+ * @returns {{name: string, options: any}[]}
+ */
+function serverBuilds(config) {
+    const found = [];
+    for (const [name, project] of Object.entries(config.projects ?? {})) {
+        const targets = readPath(project, ["architect"]) ?? readPath(project, ["targets"]);
+        const options = readPath(targets, ["build", "options"]);
+        if (!options || typeof options !== "object") continue;
+        if (options.ssr === undefined && options.server === undefined && options.outputMode === undefined) continue;
+        found.push({ name, options });
+    }
+    return found;
+}
+
+/**
+ * npx fulmine.js angular [dir] [--dry-run]
+ *
+ * Declares this package and µWebSockets.js external in every server build, which is what stops
+ * esbuild trying to inline a native binary it cannot read.
+ *
+ * @param {string[]} argv everything after the command name
+ * @returns {number} exit code
+ */
+function angular(argv) {
+    const dryRun = argv.includes("--dry-run");
+    const given = path.resolve(argv.find((arg) => !arg.startsWith("--")) ?? ".");
+    const file = fs.existsSync(given) && fs.statSync(given).isFile() ? given : path.join(given, "angular.json");
+
+    if (!fs.existsSync(file)) {
+        console.error(`no angular.json at ${file}`);
+        return 1;
+    }
+
+    const read = readJson(file);
+    if ("error" in read) {
+        console.error(read.error);
+        return 1;
+    }
+    const { data: config, source } = read;
+
+    const builds = serverBuilds(config);
+    if (!builds.length) {
+        console.error(
+            "no server build in angular.json: every build target here produces a browser bundle, and a\n" +
+                "browser bundle never loads µWebSockets.js. Nothing to declare external, and nothing changed.\n" +
+                "Run `ng add @angular/ssr` first if this application is meant to render on the server."
+        );
+        return 1;
+    }
+
+    let changed = 0;
+    for (const { name, options } of builds) {
+        const external = Array.isArray(options.externalDependencies) ? options.externalDependencies : [];
+        const missing = [SELF, "uWebSockets.js"].filter((one) => !external.includes(one));
+        if (!missing.length) {
+            console.log(`${name}: already external, nothing to change`);
+            continue;
+        }
+        options.externalDependencies = [...external, ...missing];
+        changed++;
+        console.log(`${name}: ${dryRun ? "would declare" : "declared"} ${missing.join(" and ")} external`);
+    }
+
+    if (!changed) {
+        return 0;
+    }
+    if (!dryRun) {
+        fs.writeFileSync(file, JSON.stringify(config, null, indentOf(source)) + "\n");
+    }
+
+    console.log(`\n${dryRun ? "would rewrite" : "rewrote"} ${path.relative(process.cwd(), file) || file}\n`);
+    console.log("The server.ts that `ng add @angular/ssr` generates is an ordinary Express application, so");
+    console.log("`npx fulmine.js migrate` is what changes the import in it. @angular/ssr's own");
+    console.log("AngularNodeAppEngine and writeResponseToNodeResponse work against this unchanged.\n");
+    return 0;
+}
+
+module.exports = { override, angular, detectManager, serverBuilds, indentOf };

--- a/src/adopt.js
+++ b/src/adopt.js
@@ -266,12 +266,18 @@ function serverBuilds(config) {
 function angular(argv) {
     const dryRun = argv.includes("--dry-run");
     const given = path.resolve(argv.find((arg) => !arg.startsWith("--")) ?? ".");
-    // one stat and not an existence check followed by one: the argument may be the file itself or
-    // the directory holding it, and nothing is missing if it is neither
-    const stat = fs.statSync(given, { throwIfNoEntry: false });
-    const file = stat?.isFile() ? given : path.join(given, "angular.json");
 
-    const read = readJson(file);
+    // The argument is either the file or the directory holding it, and which one comes out of
+    // reading it rather than out of a stat: a directory reads as EISDIR and a missing path as
+    // ENOENT, and in both cases the file to look for is angular.json inside it. Asked this way
+    // round because this function goes on to write the file it read, and a check on a path followed
+    // by a write to the same path is the shape of a race whatever the odds of losing it.
+    let file = given;
+    let read = readJson(file);
+    if ("error" in read && (read.code === "EISDIR" || read.code === "ENOENT")) {
+        file = path.join(given, "angular.json");
+        read = readJson(file);
+    }
     if ("error" in read) {
         console.error(read.code === "ENOENT" ? `no angular.json at ${file}` : read.error);
         return 1;

--- a/src/cli.js
+++ b/src/cli.js
@@ -31,6 +31,13 @@ limitations under the License.
 //
 // Whether this machine and this project can run it at all: the node version, the C library, the
 // µWebSockets.js binary, the base image a Dockerfile names. See src/verify.js.
+//
+// npx fulmine override [dir]
+// npx fulmine angular [dir]
+//
+// The two things a project needs that are a line in a JSON file rather than a specifier in a source
+// file: the package manager substitution, for a framework that requires express in its own code,
+// and angular.json's externalDependencies. See src/adopt.js.
 
 const fs = require("fs");
 const path = require("path");
@@ -38,6 +45,7 @@ const acorn = require("acorn");
 // the same walk express.testing asserts on, so the command and the assertions cannot drift
 const { collectRoutes } = require("./testing.js");
 const { verify } = require("./verify.js");
+const { override, angular } = require("./adopt.js");
 
 const FROM = "express";
 const TO = "fulmine.js";
@@ -823,9 +831,19 @@ function main(argv) {
     if (command === "explain") {
         return explain(argv.slice(1));
     }
+    if (command === "override") {
+        return override(argv.slice(1));
+    }
+    if (command === "angular") {
+        return angular(argv.slice(1));
+    }
     if (command !== "migrate") {
         console.log(`Usage:
   npx ${TO} migrate [dir]      rewrite require("${FROM}") and import from "${FROM}" to "${TO}"
+  npx ${TO} override [dir]     answer ${FROM} with this package for the whole dependency tree, for
+                               when a framework requires ${FROM} in its own code and not in yours
+  npx ${TO} angular [dir]      declare this package external in angular.json's server build, which
+                               esbuild otherwise tries to inline a native binary into
   npx ${TO} profile [entry]    load an application without listening and print what compiling
                                its routes decided, route by route
   npx ${TO} explain <route>    what happens when a request for that route arrives
@@ -833,7 +851,7 @@ function main(argv) {
   npx ${TO} differences        print what behaves differently, without changing anything
 
 Options:
-  --dry-run                    migrate: say what would change and change nothing`);
+  --dry-run                    migrate, override, angular: say what would change and change nothing`);
         return command ? 1 : 0;
     }
 

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -810,12 +810,19 @@ function createBodyParser(defaultType, beforeReturn, checkOptions, charsetPolicy
                 return next();
             }
 
+            // The property goes on the request before anything is decided, and its value stays
+            // undefined: body-parser's read() does exactly this, and the two halves both matter.
+            // Undefined, so a handler can still tell "nothing parsed this" from "the body was
+            // empty", which seeding an empty object would lose. Present, because `"body" in req`
+            // is how a library asks whether a parser has run at all: Apollo's express middleware
+            // refuses the request with a 500 when the property is missing, and tRPC's adapter
+            // reads the body itself when it is, so getting either half wrong breaks one of them.
+            if (!("body" in req)) {
+                req.body = undefined;
+            }
+
             // straight from the raw entries: three headers do not justify building the object
             const type = req._rawHeader("content-type");
-
-            // req.body is deliberately left undefined until a parser claims the request. That is
-            // what lets a handler tell "nothing parsed this" apart from "the body was empty",
-            // so it must not be seeded with an empty object first.
 
             // skip reading body for no content type
             // a function decides for itself, and body-parser lets it see a request that carries no

--- a/src/nest.d.ts
+++ b/src/nest.d.ts
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 Nigro Simone
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { ExpressAdapter } from "@nestjs/platform-express";
+
+/**
+ * Nest's Express adapter, listening on uWebSockets.js instead of on node.
+ *
+ * ```ts
+ * import { NestFactory } from "@nestjs/core";
+ * import { FulmineExpressAdapter } from "fulmine.js/nest";
+ *
+ * const app = await NestFactory.create(AppModule, new FulmineExpressAdapter());
+ * await app.listen(3000);
+ * ```
+ *
+ * `@nestjs/platform-express` is an optional peer dependency: this entry point is the only thing
+ * that needs it, and nothing loads it unless you import this.
+ */
+export declare class FulmineExpressAdapter extends ExpressAdapter {
+    /**
+     * @param instance an application from `fulmine()`; one is created when omitted. Pass your own
+     * when it needs options, TLS being the usual reason: `fulmine({ uwsOptions })`.
+     */
+    constructor(instance?: any);
+}

--- a/src/nest.js
+++ b/src/nest.js
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 Nigro Simone
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// require("fulmine.js/nest"): the Nest HTTP adapter, so a Nest application runs on µWS without
+// anyone having to write this file themselves.
+//
+//     import { NestFactory } from "@nestjs/core";
+//     import { FulmineExpressAdapter } from "fulmine.js/nest";
+//
+//     const app = await NestFactory.create(AppModule, new FulmineExpressAdapter());
+//     await app.listen(3000);
+//
+// @nestjs/platform-express takes any Express instance, and this is one, so everything above the
+// adapter - controllers, pipes, guards, interceptors - is untouched. Three things below it are not,
+// and they are the whole reason this file exists:
+//
+//   - initHttpServer wraps the instance in http.createServer() and listens on that. Every request
+//     would then arrive through node's parser and be replayed into µWS's shapes by node-shim.js,
+//     which is the slow path that exists for supertest. The app already answers as an http.Server,
+//     so it is the server instead of being put inside one.
+//   - registerParserMiddleware decides whether Nest's body parsers are already in the chain by
+//     scanning app.router.stack for them. There is no layer array here to scan, routes are compiled
+//     rather than kept as layers, so the answer was always "no" and a second call added a second
+//     pair. It is remembered here instead, which is the same answer by a different route.
+//   - httpsOptions asks node to make a TLS server out of the instance. TLS here belongs to µWS and
+//     is configured when the app is built, so that combination is refused with the line to write
+//     rather than silently starting a plaintext server.
+//
+// @nestjs/platform-express is an optional peer dependency: this file is the only one that requires
+// it, and nothing loads this file unless you ask for it by name.
+
+"use strict";
+
+const { ExpressAdapter } = require("@nestjs/platform-express");
+const fulmine = require("./index.js");
+
+/**
+ * Nest's Express adapter, listening on µWebSockets.js instead of on node.
+ *
+ * Pass a configured app when you need one, `new FulmineExpressAdapter(fulmine({ uwsOptions }))`;
+ * with no argument it builds a default one, the same as `new ExpressAdapter()` does.
+ */
+class FulmineExpressAdapter extends ExpressAdapter {
+    /**
+     * @param {any} [instance] an application from `fulmine()`; one is created when omitted
+     */
+    constructor(instance) {
+        super(instance || fulmine());
+        /**
+         * Whether Nest's body parsers are in the chain, standing in for the layer array Express
+         * has and this does not. See registerParserMiddleware below.
+         * @type {boolean}
+         */
+        this._parsersRegistered = false;
+    }
+
+    /**
+     * The app is the server. Nest calls this once, from NestApplication's constructor.
+     *
+     * @param {any} [options] the options NestFactory.create was given
+     * @returns {void}
+     */
+    initHttpServer(options) {
+        if (options?.httpsOptions) {
+            throw new Error(
+                "fulmine.js: httpsOptions cannot be used here, since there is no node server to give " +
+                    "them to. TLS belongs to µWS and is configured when the app is built:\n" +
+                    '  new FulmineExpressAdapter(fulmine({ uwsOptions: { key_file_name: "key.pem", cert_file_name: "cert.pem" } }))'
+            );
+        }
+        this.httpServer = this.getInstance();
+        if (options?.forceCloseConnections) {
+            // trackOpenConnections() listens for 'connection', which nothing emits: the sockets
+            // belong to µWS and never become node ones. Said out loud, because a shutdown that
+            // quietly waits forever for what it thinks it can destroy is worse than one that does
+            // not offer to. Through Nest's own logger, so the line arrives where every other line
+            // from the framework does; it is private in the typings and inherited all the same
+            /** @type {any} */ (this).logger.warn(
+                "forceCloseConnections has no effect on fulmine.js: the sockets belong to µWS. " +
+                    "app.close() stops accepting and waits for the requests in flight; an idle keep-alive " +
+                    "connection is closed by µWS through uwsOptions.idleTimeout, not by node."
+            );
+        }
+    }
+
+    /**
+     * Nest's json and urlencoded parsers, added once however often this is called.
+     *
+     * Express answers "are they there already" by scanning `app.router.stack` for a layer whose
+     * handler is named `jsonParser` or `urlencodedParser`. There is no such array here, so the scan
+     * answered no every time and a second call put a second pair in front of every request.
+     *
+     * @param {string} [prefix]
+     * @param {boolean} [rawBody]
+     * @returns {void}
+     */
+    registerParserMiddleware(prefix, rawBody) {
+        if (this._parsersRegistered) return;
+        this._parsersRegistered = true;
+        super.registerParserMiddleware(prefix, rawBody);
+    }
+}
+
+// a named export and nothing else: `import { FulmineExpressAdapter } from "fulmine.js/nest"`, which
+// is how @nestjs/platform-express exports ExpressAdapter too
+module.exports = { FulmineExpressAdapter };

--- a/src/request.js
+++ b/src/request.js
@@ -368,11 +368,12 @@ module.exports = class Request extends LazyReadable {
     /** A bodyless request whose empty end has not been delivered yet, see the constructor. */
     #emptyBody = false;
 
-    /**
-     * What a body parser left behind, and undefined until one claims the request.
-     * @type {any}
-     */
-    body;
+    // `body` is deliberately not declared here. A class field would put the property on every
+    // request, and on Express there is none until a body parser assigns one. `"body" in req` is how
+    // a library asks whether the body has already been read, and tRPC's express adapter asks
+    // exactly that: answering yes on a request nobody had parsed handed it an undefined body and
+    // turned every mutation into "Unexpected end of JSON input". Its type lives in types.d.ts,
+    // where the rest of the public request surface is described.
 
     /**
      * The response this request arrived with, linked so either reaches the other.

--- a/src/response.js
+++ b/src/response.js
@@ -589,9 +589,16 @@ module.exports = class Response extends LazyWritable {
      *
      * Nothing is written here despite the name: the headers go out when the body does.
      *
+     * Every header goes through setHeader and not through set. This is node's method, not
+     * Express's: Express does not override it, so a content-type given here keeps the value it was
+     * given, where `res.set("content-type", "text/html")` would have a charset appended to it. A
+     * handler that builds its own response and writes it with writeHead is how every meta-framework
+     * on top of Express answers, @astrojs/node and @sveltejs/adapter-node included, so the charset
+     * was being added to pages nobody asked it for.
+     *
      * @param {number} statusCode
-     * @param {string|Record<string, any>} [statusMessage] the reason phrase, or the headers
-     * @param {Record<string, any>} [headers]
+     * @param {string|Record<string, any>|any[]} [statusMessage] the reason phrase, or the headers
+     * @param {Record<string, any>|any[]} [headers]
      * @returns {this}
      */
     writeHead(statusCode, statusMessage, headers) {
@@ -605,8 +612,22 @@ module.exports = class Response extends LazyWritable {
             // string reaching here was already taken as the phrase above and simply has no keys.
             headers = /** @type {Record<string, any>} */ (statusMessage);
         }
+        if (Array.isArray(headers)) {
+            // node takes a flat list here, name then value, and not a list of pairs. An odd length
+            // is the caller's mistake and node names the argument in what it throws
+            if (headers.length % 2 !== 0) {
+                /** @type {NodeJS.ErrnoException} */
+                const err = new TypeError(`The argument 'headers' is invalid. Received ${JSON.stringify(headers)}`);
+                err.code = "ERR_INVALID_ARG_VALUE";
+                throw err;
+            }
+            for (let i = 0; i < headers.length; i += 2) {
+                this.setHeader(headers[i], headers[i + 1]);
+            }
+            return this;
+        }
         for (const header in headers) {
-            this.set(header, headers[header]);
+            this.setHeader(header, headers[header]);
         }
         return this;
     }

--- a/src/router.js
+++ b/src/router.js
@@ -1079,7 +1079,17 @@ function stepsOver(route, req) {
     if (route.bodyMethods === undefined) {
         route.bodyMethods = req.app.get("body methods") ?? null;
     }
-    return route.bodyMethods === null || !route.bodyMethods.includes(req.method);
+    if (route.bodyMethods !== null && route.bodyMethods.includes(req.method)) {
+        return false;
+    }
+    // The layer is not entered, so it leaves the one mark it would have left: the parser puts
+    // `body` on the request before it works out that there is nothing to read. A library asks
+    // `"body" in req` to tell "a parser has run" from "none has", and a skip that did not leave
+    // it would answer a GET differently from express. See the same seeding in middlewares.js
+    if (!("body" in req)) {
+        req.body = undefined;
+    }
+    return true;
 }
 
 /**

--- a/tests/tests/middlewares/body-property-presence.js
+++ b/tests/tests/middlewares/body-property-presence.js
@@ -1,0 +1,95 @@
+// whether req.body is on the request at all, which is a different question from what it holds
+//
+// body-parser puts the property there before it decides anything, and leaves it undefined on a
+// request it goes on to skip. Libraries read `"body" in req` to tell "a parser has run" from "none
+// has", and the two popular ones read it in opposite directions: Apollo's express middleware
+// answers 500 when the property is missing, and tRPC's express adapter reads the body off the
+// stream itself when it is, so a request carrying it by default loses every tRPC mutation.
+//
+// The last application is the one that pins the stepped-over layer: a GET that says nothing about a
+// body never enters the parser here, and the skip still has to leave what the parser would have.
+
+const express = require("express");
+
+/** What a handler can see about the property, without printing a body that differs by case. */
+function report(req) {
+    return {
+        present: "body" in req,
+        own: Object.prototype.hasOwnProperty.call(req, "body"),
+        type: req.body === undefined ? "undefined" : Array.isArray(req.body) ? "array" : typeof req.body,
+        value: req.body === undefined ? null : req.body
+    };
+}
+
+// no parser anywhere: nothing has claimed the request, so nothing has put the property there
+const bare = express();
+bare.set("etag", false);
+bare.all("/x", (req, res) => res.json(report(req)));
+
+// the usual front: json first, urlencoded after it
+const parsed = express();
+parsed.set("etag", false);
+parsed.use(express.json());
+parsed.use(express.urlencoded({ extended: true }));
+parsed.all("/x", (req, res) => res.json(report(req)));
+
+// something wrote a body before the parser was reached, which body-parser leaves alone
+const preset = express();
+preset.set("etag", false);
+preset.use((req, res, next) => {
+    req.body = { mine: true };
+    next();
+});
+preset.use(express.json());
+preset.all("/x", (req, res) => res.json(report(req)));
+
+const JSON_BODY = '{"a":1}';
+const FORM_BODY = "a=1";
+
+/** @param {number} port @param {string} label */
+async function ask(port, label, init) {
+    const response = await fetch(`http://localhost:${port}/x`, init);
+    console.log(label, response.status, JSON.stringify(await response.json()));
+}
+
+bare.listen(13333, () => {
+    parsed.listen(13334, () => {
+        preset.listen(13335, async () => {
+            console.log("Server is running on port 13333");
+
+            for (const [name, port] of [
+                ["no parser", 13333],
+                ["json then urlencoded", 13334],
+                ["a body set before the parser", 13335]
+            ]) {
+                console.log(`\n--- ${name} ---`);
+                // a GET that says nothing about a body: the layer may be stepped over entirely
+                await ask(port, "GET", {});
+                // a GET that names a type but still carries nothing
+                await ask(port, "GET typed", { headers: { "content-type": "application/json" } });
+                // a POST the parser claims
+                await ask(port, "POST json", {
+                    method: "POST",
+                    headers: { "content-type": "application/json" },
+                    body: JSON_BODY
+                });
+                // a POST with a type neither parser wants, so both skip after seeding
+                await ask(port, "POST text", {
+                    method: "POST",
+                    headers: { "content-type": "text/plain" },
+                    body: "hello"
+                });
+                // the second parser's turn, so the first one has already seeded and skipped
+                await ask(port, "POST form", {
+                    method: "POST",
+                    headers: { "content-type": "application/x-www-form-urlencoded" },
+                    body: FORM_BODY
+                });
+                // a POST with a body and no type at all
+                await ask(port, "POST untyped", { method: "POST", body: "hello" });
+            }
+
+            process.exit(0);
+        });
+    });
+});

--- a/tests/tests/res/res-writehead-headers.js
+++ b/tests/tests/res/res-writehead-headers.js
@@ -1,0 +1,96 @@
+// must set headers through writeHead the way node does, not the way res.set does
+//
+// writeHead is node's method and Express does not override it, so a content-type given to it keeps
+// the value it was given: `res.set("content-type", "text/html")` appends a charset and
+// `res.writeHead(200, { "content-type": "text/html" })` does not. Everything built on top of
+// Express answers this way, @astrojs/node and @sveltejs/adapter-node both build a response and
+// write it with writeHead, so the difference was on every page they rendered.
+//
+// The flat array is node's third shape: a list of name, value, name, value, and not a list of
+// pairs. An odd number of entries is refused.
+
+const express = require("express");
+const { fetchTest, sequential } = require("../../helpers.js");
+
+const app = express();
+app.set("etag", false);
+
+app.get("/object", (req, res) => {
+    res.writeHead(200, { "content-type": "text/html", "x-one": "1" });
+    res.end("object");
+});
+
+app.get("/message-and-object", (req, res) => {
+    res.writeHead(201, "Created", { "content-type": "application/json", "x-one": "1" });
+    res.end("{}");
+});
+
+app.get("/array", (req, res) => {
+    res.writeHead(200, ["content-type", "text/plain", "x-one", "1"]);
+    res.end("array");
+});
+
+app.get("/message-and-array", (req, res) => {
+    res.writeHead(202, "Accepted", ["content-type", "text/plain", "x-one", "1"]);
+    res.end("message and array");
+});
+
+app.get("/odd-array", (req, res) => {
+    try {
+        res.writeHead(200, ["content-type"]);
+        res.end("no throw");
+    } catch (err) {
+        res.end(`threw ${err.code}`);
+    }
+});
+
+// what was set before it is kept, and what writeHead names again wins
+app.get("/merges", (req, res) => {
+    res.setHeader("x-one", "before");
+    res.setHeader("x-two", "kept");
+    res.writeHead(200, { "x-one": "after" });
+    res.end("merges");
+});
+
+// a repeated header, which node keeps as a list
+app.get("/list", (req, res) => {
+    res.writeHead(200, { "x-one": ["a", "b"] });
+    res.end("list");
+});
+
+// no headers at all, which is the shape that only sets the status
+app.get("/status-only", (req, res) => {
+    res.writeHead(204);
+    res.end();
+});
+
+app.use((err, req, res, next) => {
+    res.status(500).end(`error ${err.code ?? err.message}`);
+});
+
+app.listen(13333, async () => {
+    const paths = [
+        "/object",
+        "/message-and-object",
+        "/array",
+        "/message-and-array",
+        "/odd-array",
+        "/merges",
+        "/list",
+        "/status-only"
+    ];
+
+    const responses = await sequential(paths.map((path) => () => fetchTest(`http://localhost:13333${path}`)));
+
+    for (let i = 0; i < responses.length; i++) {
+        console.log(paths[i], [
+            responses[i].status,
+            await responses[i].text(),
+            responses[i].headers.get("content-type"),
+            responses[i].headers.get("x-one"),
+            responses[i].headers.get("x-two")
+        ]);
+    }
+
+    process.exit(0);
+});

--- a/tests/unit/cli-adopt.test.js
+++ b/tests/unit/cli-adopt.test.js
@@ -1,0 +1,217 @@
+// npx fulmine override and npx fulmine angular, driven as a user drives them.
+//
+// Both edit a config file in somebody's project, so what matters as much as the line they add is
+// what they refuse to touch: a substitution already pointing somewhere else, a file that is not
+// valid JSON, an angular.json with no server build in it. Each of those has a case here.
+
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const cli = path.join(__dirname, "../../src/cli.js");
+const { version } = require("../../package.json");
+const MAJOR = version.split(".")[0];
+const WANTED = `npm:fulmine.js@^${MAJOR}`;
+
+/**
+ * @param {string[]} args
+ * @returns {{code: number, out: string}}
+ */
+function run(args) {
+    try {
+        return { code: 0, out: execFileSync(process.execPath, [cli, ...args], { encoding: "utf8" }) };
+    } catch (err) {
+        const failure = /** @type {any} */ (err);
+        return { code: failure.status ?? 1, out: `${failure.stdout ?? ""}${failure.stderr ?? ""}` };
+    }
+}
+
+/**
+ * @param {Record<string, string>} files
+ * @returns {string} the directory holding them
+ */
+function fixture(files) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fulmine-adopt-"));
+    for (const [name, content] of Object.entries(files)) {
+        fs.writeFileSync(path.join(dir, name), content);
+    }
+    test.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+    return dir;
+}
+
+/** @param {string} dir @param {string} name @returns {any} */
+function readJson(dir, name) {
+    return JSON.parse(fs.readFileSync(path.join(dir, name), "utf8"));
+}
+
+test("override writes npm's overrides when a package-lock is what is there", () => {
+    const dir = fixture({
+        "package.json": JSON.stringify({ name: "demo" }, null, 2) + "\n",
+        "package-lock.json": "{}"
+    });
+    const { code, out } = run(["override", dir]);
+    assert.strictEqual(code, 0);
+    assert.match(out, /npm, because package-lock\.json is here/);
+    assert.deepStrictEqual(readJson(dir, "package.json").overrides, { express: WANTED });
+});
+
+test("override writes pnpm.overrides for pnpm and resolutions for yarn", () => {
+    const pnpm = fixture({ "package.json": "{}\n", "pnpm-lock.yaml": "" });
+    assert.strictEqual(run(["override", pnpm]).code, 0);
+    assert.deepStrictEqual(readJson(pnpm, "package.json").pnpm.overrides, { express: WANTED });
+
+    const yarn = fixture({ "package.json": "{}\n", "yarn.lock": "" });
+    assert.strictEqual(run(["override", yarn]).code, 0);
+    assert.deepStrictEqual(readJson(yarn, "package.json").resolutions, { express: WANTED });
+});
+
+test("override believes the packageManager field over any lockfile lying around", () => {
+    const dir = fixture({
+        "package.json": JSON.stringify({ packageManager: "pnpm@9.0.0" }) + "\n",
+        "package-lock.json": "{}"
+    });
+    const { out } = run(["override", dir]);
+    assert.match(out, /pnpm, because the packageManager field says pnpm/);
+    assert.deepStrictEqual(readJson(dir, "package.json").pnpm.overrides, { express: WANTED });
+});
+
+test("override keeps the indentation the file already used", () => {
+    const dir = fixture({ "package.json": '{\n\t"name": "demo"\n}\n' });
+    run(["override", dir]);
+    assert.match(fs.readFileSync(path.join(dir, "package.json"), "utf8"), /\n\t"resolutions|\n\t"overrides/);
+});
+
+test("override changes nothing on --dry-run", () => {
+    const before = JSON.stringify({ name: "demo" }) + "\n";
+    const dir = fixture({ "package.json": before });
+    const { code, out } = run(["override", dir, "--dry-run"]);
+    assert.strictEqual(code, 0);
+    assert.match(out, /would add to package\.json/);
+    assert.strictEqual(fs.readFileSync(path.join(dir, "package.json"), "utf8"), before);
+});
+
+test("override says there is nothing to do when it is already there", () => {
+    const dir = fixture({ "package.json": JSON.stringify({ overrides: { express: WANTED } }) + "\n" });
+    const { code, out } = run(["override", dir]);
+    assert.strictEqual(code, 0);
+    assert.match(out, /already says npm:fulmine\.js/);
+});
+
+test("override refuses to overwrite somebody else's substitution", () => {
+    const dir = fixture({ "package.json": JSON.stringify({ overrides: { express: "^5.1.0" } }) + "\n" });
+    const { code, out } = run(["override", dir]);
+    assert.strictEqual(code, 1);
+    assert.match(out, /which is not this package/);
+    assert.deepStrictEqual(readJson(dir, "package.json").overrides, { express: "^5.1.0" });
+});
+
+test("override refuses bun, which cannot load the binary at all", () => {
+    const dir = fixture({ "package.json": "{}\n", "bun.lock": "" });
+    const { code, out } = run(["override", dir]);
+    assert.strictEqual(code, 1);
+    assert.match(out, /bun does not load it/);
+});
+
+test("override says which file it could not read rather than throwing a parser error", () => {
+    const dir = fixture({ "package.json": "{ not json" });
+    const { code, out } = run(["override", dir]);
+    assert.strictEqual(code, 1);
+    assert.match(out, /is not valid JSON and was left alone/);
+});
+
+test("override reports a directory with no package.json in it", () => {
+    const dir = fixture({});
+    const { code, out } = run(["override", dir]);
+    assert.strictEqual(code, 1);
+    assert.match(out, /no package\.json in/);
+});
+
+const SSR_CONFIG = {
+    projects: {
+        demo: {
+            architect: {
+                build: { options: { browser: "src/main.ts", ssr: { entry: "src/server.ts" } } }
+            }
+        },
+        widget: { architect: { build: { options: { browser: "src/main.ts" } } } }
+    }
+};
+
+test("angular declares both names external in the server build and leaves the browser one alone", () => {
+    const dir = fixture({ "angular.json": JSON.stringify(SSR_CONFIG, null, 2) + "\n" });
+    const { code, out } = run(["angular", dir]);
+    assert.strictEqual(code, 0);
+    assert.match(out, /demo: declared fulmine\.js and uWebSockets\.js external/);
+    const config = readJson(dir, "angular.json");
+    assert.deepStrictEqual(config.projects.demo.architect.build.options.externalDependencies, [
+        "fulmine.js",
+        "uWebSockets.js"
+    ]);
+    assert.strictEqual(config.projects.widget.architect.build.options.externalDependencies, undefined);
+});
+
+test("angular keeps what was already declared external", () => {
+    const config = JSON.parse(JSON.stringify(SSR_CONFIG));
+    config.projects.demo.architect.build.options.externalDependencies = ["sharp"];
+    const dir = fixture({ "angular.json": JSON.stringify(config, null, 2) + "\n" });
+    run(["angular", dir]);
+    assert.deepStrictEqual(readJson(dir, "angular.json").projects.demo.architect.build.options.externalDependencies, [
+        "sharp",
+        "fulmine.js",
+        "uWebSockets.js"
+    ]);
+});
+
+test("angular is idempotent", () => {
+    const dir = fixture({ "angular.json": JSON.stringify(SSR_CONFIG, null, 2) + "\n" });
+    run(["angular", dir]);
+    const { code, out } = run(["angular", dir]);
+    assert.strictEqual(code, 0);
+    assert.match(out, /already external, nothing to change/);
+});
+
+test("angular reads the newer targets key as well as architect", () => {
+    const dir = fixture({
+        "angular.json":
+            JSON.stringify({ projects: { demo: { targets: { build: { options: { outputMode: "server" } } } } } }) + "\n"
+    });
+    assert.strictEqual(run(["angular", dir]).code, 0);
+    assert.deepStrictEqual(readJson(dir, "angular.json").projects.demo.targets.build.options.externalDependencies, [
+        "fulmine.js",
+        "uWebSockets.js"
+    ]);
+});
+
+test("angular changes nothing on --dry-run", () => {
+    const before = JSON.stringify(SSR_CONFIG, null, 2) + "\n";
+    const dir = fixture({ "angular.json": before });
+    const { code, out } = run(["angular", dir, "--dry-run"]);
+    assert.strictEqual(code, 0);
+    assert.match(out, /would declare/);
+    assert.strictEqual(fs.readFileSync(path.join(dir, "angular.json"), "utf8"), before);
+});
+
+test("angular says so when every build target is a browser bundle", () => {
+    const dir = fixture({
+        "angular.json": JSON.stringify({ projects: { a: { architect: { build: { options: {} } } } } }) + "\n"
+    });
+    const { code, out } = run(["angular", dir]);
+    assert.strictEqual(code, 1);
+    assert.match(out, /no server build in angular\.json/);
+});
+
+test("angular reports a directory with no angular.json in it", () => {
+    const dir = fixture({});
+    const { code, out } = run(["angular", dir]);
+    assert.strictEqual(code, 1);
+    assert.match(out, /no angular\.json at/);
+});
+
+test("the usage text names both commands", () => {
+    const { out } = run([]);
+    assert.match(out, /npx fulmine\.js override \[dir\]/);
+    assert.match(out, /npx fulmine\.js angular \[dir\]/);
+});

--- a/tests/unit/cli-adopt.test.js
+++ b/tests/unit/cli-adopt.test.js
@@ -203,9 +203,26 @@ test("angular says so when every build target is a browser bundle", () => {
     assert.match(out, /no server build in angular\.json/);
 });
 
+test("angular takes the file itself as well as the directory holding it", () => {
+    const dir = fixture({ "angular.json": JSON.stringify(SSR_CONFIG, null, 2) + "\n" });
+    const { code, out } = run(["angular", path.join(dir, "angular.json")]);
+    assert.strictEqual(code, 0);
+    assert.match(out, /demo: declared/);
+    assert.deepStrictEqual(readJson(dir, "angular.json").projects.demo.architect.build.options.externalDependencies, [
+        "fulmine.js",
+        "uWebSockets.js"
+    ]);
+});
+
 test("angular reports a directory with no angular.json in it", () => {
     const dir = fixture({});
     const { code, out } = run(["angular", dir]);
+    assert.strictEqual(code, 1);
+    assert.match(out, /no angular\.json at/);
+});
+
+test("angular reports a path that is not there at all", () => {
+    const { code, out } = run(["angular", path.join(fixture({}), "nowhere")]);
     assert.strictEqual(code, 1);
     assert.match(out, /no angular\.json at/);
 });

--- a/tests/unit/nest-adapter.test.js
+++ b/tests/unit/nest-adapter.test.js
@@ -1,0 +1,65 @@
+// fulmine.js/nest: the three things the adapter changes about @nestjs/platform-express.
+//
+// The end to end check, a whole Nest application answering the same bytes as one on Express, lives
+// in integrations/cases/nest.js and needs Nest installed beside this project. This file is the
+// unit of it: the adapter's own decisions, asserted where they are made.
+
+require("reflect-metadata");
+const test = require("node:test");
+const assert = require("node:assert");
+const http = require("node:http");
+const { FulmineExpressAdapter } = require("../../src/nest.js");
+const fulmine = require("../../src/index.js");
+
+test("with no instance it builds a fulmine app, not an express one", () => {
+    const adapter = new FulmineExpressAdapter();
+    assert.ok(adapter.getInstance().uwsApp, "the instance should be one of ours");
+});
+
+test("the app is the server rather than being wrapped in one", () => {
+    const app = fulmine();
+    const adapter = new FulmineExpressAdapter(app);
+    adapter.initHttpServer({});
+    assert.strictEqual(adapter.getHttpServer(), app);
+    // and it still answers as a server to everything that asks, which is what Nest goes on to use
+    assert.ok(adapter.getHttpServer() instanceof http.Server);
+});
+
+test("httpsOptions is refused with the line to write instead", () => {
+    const adapter = new FulmineExpressAdapter(fulmine());
+    assert.throws(() => adapter.initHttpServer({ httpsOptions: { key: "x", cert: "y" } }), /uwsOptions/);
+});
+
+test("forceCloseConnections says it has nothing to destroy", () => {
+    const adapter = new FulmineExpressAdapter(fulmine());
+    const said = [];
+    /** @type {any} */ (adapter).logger = { warn: (/** @type {string} */ line) => said.push(line) };
+    adapter.initHttpServer({ forceCloseConnections: true });
+    assert.strictEqual(said.length, 1);
+    assert.match(said[0], /sockets belong to µWS/);
+});
+
+test("the body parsers go in once however often Nest asks for them", () => {
+    const adapter = new FulmineExpressAdapter(fulmine());
+    const added = [];
+    /** @type {any} */ (adapter).use = (/** @type {any} */ fn) => added.push(fn.name);
+
+    adapter.registerParserMiddleware();
+    assert.deepStrictEqual(added, ["jsonParser", "urlencodedParser"]);
+
+    // Nest calls this again on a second init, and on express the scan of app.router.stack would
+    // find them and skip. There is no such array here, so the adapter remembers instead
+    adapter.registerParserMiddleware();
+    assert.deepStrictEqual(added, ["jsonParser", "urlencodedParser"]);
+});
+
+test("an unwrapped ExpressAdapter would have wrapped the instance in a node server", async () => {
+    // the claim the adapter exists to make, asserted against the thing it replaces rather than
+    // stated in a comment: a plain ExpressAdapter puts a node server in front of the app
+    const { ExpressAdapter } = require("@nestjs/platform-express");
+    const app = fulmine();
+    const plain = new ExpressAdapter(app);
+    plain.initHttpServer({});
+    assert.notStrictEqual(plain.getHttpServer(), app);
+    plain.getHttpServer().close();
+});


### PR DESCRIPTION
Frameworks built on Express reach parts of the Express surface an application never touches, and nothing here was testing that. `integrations/` now serves the same application twice, once on Express and once on this, and compares the two byte for byte: Nest, Next, Astro, SvelteKit, React Router, Apollo and tRPC.

It found two real bugs. `req.body` was on every request where Express has none, so tRPC read an empty body and answered "Unexpected end of JSON input" to every mutation, and missing where Express has one, which Apollo answers with a 500. And `res.writeHead` set headers the way `res.set` does, so a content-type given to it came back with a charset node never adds, on every page Astro and SvelteKit rendered.

Also here: `fulmine.js/nest` ships the Nest adapter the readme used to ask people to write, and `npx fulmine.js override` and `npx fulmine.js angular` write the two config files `migrate` cannot reach.

Both fixes have a comparison test checked to fail without them. 469/469, unit 350, Express 1130/0, integrations 7/7, fuzz clean. `--self` has the same 12 reds as `main`.