### PR TITLE
The --self reference arm skips the assertions about the optimizer it turns off

### DIFF
--- a/tests/generic-preload.cjs
+++ b/tests/generic-preload.cjs
@@ -33,6 +33,14 @@ function wrapFactory(factory) {
     };
     Object.setPrototypeOf(wrapped, factory);
     Object.assign(wrapped, factory);
+    // expectNative and expectDeclarative assert that a route was registered on the µWS router, or
+    // compiled into a response written at startup. The line above has just turned both off, so in
+    // this arm they assert something the run has deliberately arranged to be false, and eleven
+    // files failed here for that reason alone. Skipped rather than answered: the assertions still
+    // run in the other arm and in every ordinary `npm test`, which is where they belong. What this
+    // arm compares is the two ways of answering a request, and a file cannot compare them if it
+    // throws before it has answered one.
+    wrapped.testing = { ...factory.testing, expectNative: () => {}, expectDeclarative: () => {} };
     return wrapped;
 }
 


### PR DESCRIPTION
`npm test -- --self` serves every file twice with this framework, the reference arm with `native routes` off. Eleven files call `expectDeclarative`, which asserts that their routes are compiled into a response written at startup, and that is exactly what the reference arm has just turned off. So they threw before answering anything, and `--self` has been 11 red on main for a while: not a divergence, an assertion about a setting the run deliberately unsets.

The preload that turns the optimizer off now also skips `expectNative` and `expectDeclarative`. Both still run in the other arm and in every ordinary `npm test`.

`--self` goes from 458/11 to 469/0, and the eleven files are compared for the first time rather than failing before they print. Both directions checked with a bug put back: a compiled response writing a different header value turns `--self` red, and stopping compilation turns the normal run red with "no longer compiled".