### PR TITLE
fix(response): the response is destroyed when the client hangs up, so res.on(close) runs

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -893,6 +893,16 @@ function onNativeAborted() {
     // error goes only to whoever listens for it, since a destroy(err) with no listener
     // would take down the process
     request.emit("aborted");
+    // and the response dies between the two, which is where node puts it. Destroyed rather than
+    // told to emit 'close', because being destroyed is the state express is in here and everything
+    // after it follows from that state rather than having to be reproduced: 'close' goes out once,
+    // a later res.write returns false and calls its callback with ERR_STREAM_DESTROYED, and no
+    // 'error' is emitted, which a destroy(err) here would.
+    //
+    // Without this a handler learnt about the abort only from a write failing, so one that had sent
+    // its head and gone quiet never learnt at all. `res.on("close")` is where cancellation hangs in
+    // every proxy and every streaming endpoint, so it never ran for exactly the shape that needs it.
+    response.destroy();
     request.destroy(request.listenerCount("error") > 0 ? err : undefined);
     response.socket?.emit("error", err);
 }

--- a/tests/tests/res/res-close-on-client-abort.js
+++ b/tests/tests/res/res-close-on-client-abort.js
@@ -1,0 +1,72 @@
+// must tell the response the client hung up, whether or not the handler writes again
+//
+// `res.on("close", ...)` is how code learns the visitor has gone and stops working for them. Every
+// proxy and every streaming endpoint hangs its cancellation on it. Node emits it when the connection
+// goes, in the order 'aborted' on the request, 'close' on the response, 'close' on the request.
+//
+// The second route is the one that matters and the first one hides it: a handler that keeps writing
+// finds out anyway, because the write itself fails. A handler that has sent the head and is waiting
+// for something, which is what an SSE endpoint or anything in front of a slow upstream looks like,
+// writes nothing and has only this event to go on.
+//
+// A raw request, because the socket has to be destroyed mid-response and fetch cannot do that.
+
+const express = require("express");
+const http = require("http");
+
+const app = express();
+app.set("etag", false);
+
+/** @type {Record<string, string[]>} */
+const fired = { idle: [], writing: [] };
+
+/** Records the four events node emits around a client abort, in the order they arrive. */
+function record(name, req, res) {
+    res.on("close", () => fired[name].push("res close"));
+    res.on("error", (err) => fired[name].push(`res error ${err.code ?? err.message}`));
+    req.on("aborted", () => fired[name].push("req aborted"));
+    req.on("close", () => fired[name].push("req close"));
+}
+
+// the head goes out, and then nothing ever again
+app.get("/idle", (req, res) => {
+    res.set("content-type", "text/plain");
+    res.write("first");
+    record("idle", req, res);
+});
+
+// the same, and then one write long after the client has gone
+app.get("/writing", (req, res) => {
+    res.set("content-type", "text/plain");
+    res.write("first");
+    record("writing", req, res);
+    setTimeout(() => {
+        fired.writing.push(`late write returned ${res.write("late")}`);
+    }, 150);
+});
+
+/**
+ * Asks for a path and destroys the socket as soon as the first byte of body arrives, which is what
+ * a browser does when the tab closes. Resolves once the server has had time to notice.
+ */
+function askAndHangUp(path) {
+    return new Promise((resolve) => {
+        const request = http.get({ host: "127.0.0.1", port: 13333, path }, (response) => {
+            response.on("data", () => request.destroy());
+        });
+        request.on("error", () => {});
+        setTimeout(resolve, 400);
+    });
+}
+
+app.listen(13333, async () => {
+    console.log("Server is running on port 13333");
+
+    await askAndHangUp("/idle");
+    console.log("idle   ", JSON.stringify(fired.idle));
+
+    await askAndHangUp("/writing");
+    console.log("writing", JSON.stringify(fired.writing));
+
+    process.exit(0);
+});


### PR DESCRIPTION
`res.on("close", ...)` never ran when a client hung up on a handler that had sent its head and gone quiet. That is the shape of every SSE endpoint and anything waiting on a slow upstream, and it is where cancellation is hung, so the work carried on for a visitor who had already left. A handler that kept writing found out anyway, because the write failed, which is why this stayed hidden.

The abort handler emitted `aborted` and `close` on the request and nothing on the response. It now destroys the response too, between the two, which is the state Express is in at that point. Everything else follows from the state rather than being reproduced: `close` goes out once and in node's order, a later `res.write` returns false and calls its callback with `ERR_STREAM_DESTROYED`, and the spurious `res 'error'` that a failing write used to raise is gone.

```
before  idle    ["req aborted","req close"]
after   idle    ["req aborted","res close","req close"]     same as express
```

Comparison test in `tests/tests/res/res-close-on-client-abort.js`, both shapes, checked red without the fix. Full suites green, `--self` 470/470, express 1130/0, integrations 7/7, fuzz and fuzz:session clean.